### PR TITLE
Feature/document user permissions view

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ dokku letsencrypt:enable dev-teaching-api
 ## when it succeeds, re-enable the cloudflare proxy for domain.tld...
 ```
 
+### Speed Improvements
+If the API and the Database are running on the same server, you can improve the speed by disabling the tcp connection for the database. This can be done by setting the `DATABASE_URL` to `postgresql://teaching_website:teaching_website@localhost/teaching_website?sslmode=disable`.
+
 ## Troubleshooting
 
 > [!Caution]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",
-    "connect-pg-simple": "^9.0.1",
+    "@quixo3/prisma-session-store": "^3.1.13",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-session": "^1.18.0",
@@ -38,9 +38,9 @@
   },
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^10.9.1",
-    "@types/connect-pg-simple": "^7.0.3",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/express-session": "^1.18.0",
     "@types/lodash": "^4.17.5",
     "@types/morgan": "^1.9.9",
     "@types/node": "^20.14.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@prisma/client": "^5.16.1",
+    "@prisma/client": "^5.18.0",
     "@quixo3/prisma-session-store": "^3.1.13",
     "cors": "^2.8.5",
     "express": "^4.19.2",
@@ -48,7 +48,7 @@
     "dotenv-cli": "^7.4.2",
     "nodemon": "^3.1.3",
     "prettier": "^3.3.2",
-    "prisma": "^5.16.1",
+    "prisma": "^5.18.0",
     "prisma-dbml-generator": "^0.12.0",
     "prisma-docs-generator": "^0.8.0",
     "prisma-erd-generator": "^1.11.2",

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -8,39 +8,42 @@ Table users {
   firstName String [not null]
   lastName String [not null]
   isAdmin Boolean [not null, default: false]
-  documents documents [not null]
-  studentGroups student_groups [not null]
-  rootUserPermissions root_user_permissions [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [default: `now()`, not null]
+  documents documents [not null]
+  rootUserPermissions root_user_permissions [not null]
+  studentGroups student_groups [not null]
+  view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
 Table student_groups {
   id String [pk]
   name String [not null, default: '']
   description String [not null, default: '']
-  users users [not null]
   parentId String
-  parent student_groups
-  children student_groups [not null]
-  rootGroupPermissions root_group_permissions [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [default: `now()`, not null]
+  rootGroupPermissions root_group_permissions [not null]
+  parent student_groups
+  children student_groups [not null]
+  users users [not null]
+  view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
 Table documents {
   id String [pk]
-  author users [not null]
   authorId String [not null]
   type String [not null]
   data Json [not null]
   parentId String
-  parent documents
-  children documents [not null]
-  documentRoot document_roots [not null]
   documentRootId String [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [default: `now()`, not null]
+  author users [not null]
+  documentRoot document_roots [not null]
+  parent documents
+  children documents [not null]
+  view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
 Table document_roots {
@@ -50,30 +53,55 @@ Table document_roots {
   documents documents [not null]
   rootGroupPermissions root_group_permissions [not null]
   rootUserPermissions root_user_permissions [not null]
+  view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
 Table root_group_permissions {
   id String [pk]
   access Access [not null]
-  studentGroup student_groups [not null]
   studentGroupId String [not null]
-  documentRoot document_roots [not null]
   documentRootId String [not null]
+  documentRoot document_roots [not null]
+  studentGroup student_groups [not null]
+  view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
 Table root_user_permissions {
   id String [pk]
   access Access [not null]
-  user users [not null]
   userId String [not null]
-  documentRoot document_roots [not null]
   documentRootId String [not null]
+  documentRoot document_roots [not null]
+  user users [not null]
+  view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
 Table sessions {
   sid String [pk]
   sess Json [not null]
   expire DateTime [not null]
+}
+
+Table view__document_user_permissions {
+  documentRootId String [not null]
+  userId String [not null]
+  access Access [not null]
+  documentId String [not null]
+  rootUserPermissionId String
+  rootGroupPermissionId String
+  groupId String
+  documentRoot document_roots [not null]
+  user users [not null]
+  document documents [not null]
+  rootUserPermission root_user_permissions
+  rootGroupPermission root_group_permissions
+  group student_groups
+
+  indexes {
+    (documentRootId, userId, access, documentId) [unique]
+  }
+
+  Note: 'The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.'
 }
 
 Table documents {
@@ -96,14 +124,26 @@ Ref: student_groups.parentId - student_groups.id [delete: Cascade]
 
 Ref: documents.authorId > users.id [delete: Cascade]
 
-Ref: documents.parentId - documents.id [delete: Cascade]
-
 Ref: documents.documentRootId > document_roots.id [delete: Cascade]
 
-Ref: root_group_permissions.studentGroupId > student_groups.id [delete: Cascade]
+Ref: documents.parentId - documents.id [delete: Cascade]
 
 Ref: root_group_permissions.documentRootId > document_roots.id [delete: Cascade]
 
-Ref: root_user_permissions.userId > users.id [delete: Cascade]
+Ref: root_group_permissions.studentGroupId > student_groups.id [delete: Cascade]
 
 Ref: root_user_permissions.documentRootId > document_roots.id [delete: Cascade]
+
+Ref: root_user_permissions.userId > users.id [delete: Cascade]
+
+Ref: view__document_user_permissions.documentRootId > document_roots.id
+
+Ref: view__document_user_permissions.userId > users.id
+
+Ref: view__document_user_permissions.documentId > documents.id
+
+Ref: view__document_user_permissions.rootUserPermissionId > root_user_permissions.id
+
+Ref: view__document_user_permissions.rootGroupPermissionId > root_group_permissions.id
+
+Ref: view__document_user_permissions.groupId > student_groups.id

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -76,10 +76,11 @@ Table root_user_permissions {
   view_DocumentUserPermissions view__document_user_permissions [not null]
 }
 
-Table sessions {
-  sid String [pk]
-  sess Json [not null]
-  expire DateTime [not null]
+Table Session {
+  id String [pk]
+  sid String [unique, not null]
+  data String [not null]
+  expiresAt DateTime [not null]
 }
 
 Table view__document_user_permissions {

--- a/prisma/migrations/20240813214732_add_document_user_permissions_view/migration.sql
+++ b/prisma/migrations/20240813214732_add_document_user_permissions_view/migration.sql
@@ -1,0 +1,107 @@
+CREATE INDEX document_root_id_index ON document_roots (id);
+CREATE INDEX document_author_id_index ON documents (author_id);
+CREATE INDEX root_user_permissions_user_id_index ON root_user_permissions (user_id);
+CREATE INDEX root_user_permissions_document_root_id_index ON root_user_permissions (document_root_id);
+
+CREATE OR REPLACE VIEW view__document_user_permissions AS
+    SELECT DISTINCT
+        document_root_id,
+        user_id,
+        access,
+        document_id,
+        root_user_permission_id,
+        root_group_permission_id,
+        group_id
+    FROM (
+        SELECT
+            document_root_id,
+            user_id,
+            access,
+            document_id,
+            root_user_permission_id,
+            root_group_permission_id,
+            group_id,
+            ROW_NUMBER() OVER (PARTITION BY document_root_id, user_id ORDER BY access DESC) AS rn  -- rank by access level
+        FROM (
+                -- get all documents where the user is the author
+                SELECT
+                    document_roots.id AS document_root_id,
+                    documents.author_id AS user_id,
+                    document_roots.access AS access,
+                    documents.id AS document_id,
+                    NULL::uuid AS root_user_permission_id,
+                    NULL::uuid AS root_group_permission_id,
+                    NULL::uuid AS group_id
+                FROM 
+                    document_roots
+                    INNER JOIN documents ON document_roots.id=documents.document_root_id
+            UNION
+                -- get all documents where the user has been granted shared access
+                -- or the access has been extended by user permissions
+                SELECT
+                    document_roots.id AS document_root_id,
+                    rup.user_id AS user_id,
+                    rup.access AS access,
+                    documents.id AS document_id,
+                    rup.id AS root_user_permission_id,
+                    NULL::uuid AS root_group_permission_id,
+                    NULL::uuid AS group_id
+                FROM 
+                    document_roots
+                    INNER JOIN documents ON document_roots.id=documents.document_root_id
+                    INNER JOIN root_user_permissions rup 
+                        ON (
+                            document_roots.id = rup.document_root_id 
+                            AND (
+                                documents.author_id = rup.user_id
+                                OR
+                                rup.access >= document_roots.shared_access
+                            )
+                        )
+            UNION
+                -- all group-based permissions for the documents author
+                SELECT
+                    document_roots.id AS document_root_id,
+                    documents.author_id AS user_id,
+                    rgp.access AS access,
+                    documents.id AS document_id,
+                    NULL::uuid AS root_user_permission_id,
+                    rgp.id AS root_group_permission_id,
+                    sg.id AS group_id
+                FROM 
+                    document_roots
+                    INNER JOIN documents ON documents.document_root_id=document_roots.id
+                    INNER JOIN root_group_permissions rgp ON document_roots.id=rgp.document_root_id
+                    INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                    INNER JOIN "_StudentGroupToUser" sg_to_user 
+                        ON (
+                            sg_to_user."A"=sg.id 
+                            AND sg_to_user."B"=documents.author_id
+                        )
+            UNION
+                -- all group based permissions for the user, which is not the author
+                SELECT
+                    document_roots.id AS document_root_id,
+                    sg_to_user."B" AS user_id,
+                    rgp.access AS access,
+                    documents.id AS document_id,
+                    NULL::uuid AS root_user_permission_id,
+                    rgp.id AS root_group_permission_id,
+                    sg.id AS group_id
+                FROM 
+                    document_roots
+                    INNER JOIN documents ON document_roots.id=documents.document_root_id
+                    INNER JOIN root_group_permissions rgp 
+                        ON (
+                            document_roots.id=rgp.document_root_id 
+                            AND rgp.access >= document_roots.shared_access
+                        )
+                    INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                    INNER JOIN "_StudentGroupToUser" sg_to_user 
+                        ON (
+                            sg_to_user."A"=sg.id 
+                            AND sg_to_user."B"!=documents.author_id
+                        )
+        ) AS document_user_permissions
+    ) AS ranked_permissions
+    WHERE rn = 1; -- filter out all but the highest ranked permission

--- a/prisma/migrations/20240814115642_use_prisma_session_store/migration.sql
+++ b/prisma/migrations/20240814115642_use_prisma_session_store/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the `sessions` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "sessions";
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "sid" TEXT NOT NULL,
+    "data" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sid_key" ON "Session"("sid");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,6 @@
-datasource db {
-  url        = env("DATABASE_URL")
-  provider   = "postgresql"
-  extensions = [pg_trgm, pgcrypto]
-}
-
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["views", "postgresqlExtensions", "relationJoins"]
+  previewFeatures = ["postgresqlExtensions", "views", "relationJoins"]
 }
 
 generator docs {
@@ -18,105 +12,99 @@ generator dbml {
   provider = "prisma-dbml-generator"
 }
 
-// generator erd {
-//   provider = "prisma-erd-generator"
-//   output   = "../docs/erd.svg"
-// }
+datasource db {
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [pg_trgm, pgcrypto]
+}
 
 model User {
-  id        String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  email     String  @unique
-  firstName String  @map("first_name")
-  lastName  String  @map("last_name")
-  isAdmin   Boolean @default(false) @map("is_admin")
-
-  documents Document[] @relation("documents")
-
-  studentGroups StudentGroup[]
-
-  rootUserPermissions RootUserPermission[] @relation("root_user_to_user_permission")
-
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+  id                           String                         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email                        String                         @unique
+  firstName                    String                         @map("first_name")
+  lastName                     String                         @map("last_name")
+  isAdmin                      Boolean                        @default(false) @map("is_admin")
+  createdAt                    DateTime                       @default(now()) @map("created_at")
+  updatedAt                    DateTime                       @default(now()) @updatedAt @map("updated_at")
+  documents                    Document[]                     @relation("documents")
+  rootUserPermissions          RootUserPermission[]           @relation("root_user_to_user_permission")
+  studentGroups                StudentGroup[]                 @relation("StudentGroupToUser")
+  view_DocumentUserPermissions view_DocumentUserPermissions[]
 
   @@map("users")
 }
 
 model StudentGroup {
-  id          String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name        String @default("")
-  description String @default("")
-
-  users User[]
-
-  parentId String?        @map("parent_id") @db.Uuid
-  parent   StudentGroup?  @relation("parent_student_group", fields: [parentId], references: [id], onDelete: Cascade)
-  children StudentGroup[] @relation("parent_student_group")
-
-  rootGroupPermissions RootGroupPermission[] @relation("root_group_to_student_group_permission")
-
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+  id                           String                         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name                         String                         @default("")
+  description                  String                         @default("")
+  parentId                     String?                        @map("parent_id") @db.Uuid
+  createdAt                    DateTime                       @default(now()) @map("created_at")
+  updatedAt                    DateTime                       @default(now()) @updatedAt @map("updated_at")
+  rootGroupPermissions         RootGroupPermission[]          @relation("root_group_to_student_group_permission")
+  parent                       StudentGroup?                  @relation("parent_student_group", fields: [parentId], references: [id], onDelete: Cascade)
+  children                     StudentGroup[]                 @relation("parent_student_group")
+  users                        User[]                         @relation("StudentGroupToUser")
+  view_DocumentUserPermissions view_DocumentUserPermissions[]
 
   @@map("student_groups")
 }
 
 model Document {
-  id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id                           String                         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  authorId                     String                         @map("author_id") @db.Uuid
+  type                         String
+  data                         Json
+  parentId                     String?                        @map("parent_id") @db.Uuid
+  documentRootId               String                         @map("document_root_id") @db.Uuid
+  createdAt                    DateTime                       @default(now()) @map("created_at")
+  updatedAt                    DateTime                       @default(now()) @updatedAt @map("updated_at")
+  author                       User                           @relation("documents", fields: [authorId], references: [id], onDelete: Cascade)
+  documentRoot                 DocumentRoot                   @relation("documents", fields: [documentRootId], references: [id], onDelete: Cascade)
+  parent                       Document?                      @relation("connected_documents", fields: [parentId], references: [id], onDelete: Cascade)
+  children                     Document[]                     @relation("connected_documents")
+  view_DocumentUserPermissions view_DocumentUserPermissions[]
 
-  author   User   @relation("documents", fields: [authorId], references: [id], onDelete: Cascade)
-  authorId String @map("author_id") @db.Uuid
-
-  type String
-  data Json
-
-  parentId String?    @map("parent_id") @db.Uuid
-  parent   Document?  @relation("connected_documents", fields: [parentId], references: [id], onDelete: Cascade)
-  children Document[] @relation("connected_documents")
-
-  documentRoot   DocumentRoot @relation("documents", fields: [documentRootId], references: [id], onDelete: Cascade)
-  documentRootId String       @map("document_root_id") @db.Uuid
-
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
-
+  @@index([authorId], map: "document_author_id_index")
   @@map("documents")
 }
 
 model DocumentRoot {
-  id           String     @id @db.Uuid
-  access       Access     @default(RW)
-  sharedAccess Access     @default(None) @map("shared_access")
-  documents    Document[] @relation("documents")
+  id                           String                         @id @db.Uuid
+  access                       Access                         @default(RW)
+  sharedAccess                 Access                         @default(None) @map("shared_access")
+  documents                    Document[]                     @relation("documents")
+  rootGroupPermissions         RootGroupPermission[]          @relation("root_group_to_document_root_permission")
+  rootUserPermissions          RootUserPermission[]           @relation("root_user_to_document_root_permission")
+  view_DocumentUserPermissions view_DocumentUserPermissions[]
 
-  rootGroupPermissions RootGroupPermission[] @relation("root_group_to_document_root_permission")
-  rootUserPermissions  RootUserPermission[]  @relation("root_user_to_document_root_permission")
-
+  @@index([id], map: "document_root_id_index")
   @@map("document_roots")
 }
 
 model RootGroupPermission {
-  id             String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  access         Access
-  studentGroup   StudentGroup @relation("root_group_to_student_group_permission", fields: [studentGroupId], references: [id], onDelete: Cascade)
-  studentGroupId String       @map("student_group_id") @db.Uuid
-
-  documentRoot   DocumentRoot @relation("root_group_to_document_root_permission", fields: [documentRootId], references: [id], onDelete: Cascade)
-  documentRootId String       @map("document_root_id") @db.Uuid
+  id                           String                         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  access                       Access
+  studentGroupId               String                         @map("student_group_id") @db.Uuid
+  documentRootId               String                         @map("document_root_id") @db.Uuid
+  documentRoot                 DocumentRoot                   @relation("root_group_to_document_root_permission", fields: [documentRootId], references: [id], onDelete: Cascade)
+  studentGroup                 StudentGroup                   @relation("root_group_to_student_group_permission", fields: [studentGroupId], references: [id], onDelete: Cascade)
+  view_DocumentUserPermissions view_DocumentUserPermissions[]
 
   @@map("root_group_permissions")
 }
 
 model RootUserPermission {
-  id     String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  access Access
+  id                           String                         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  access                       Access
+  userId                       String                         @map("user_id") @db.Uuid
+  documentRootId               String                         @map("document_root_id") @db.Uuid
+  documentRoot                 DocumentRoot                   @relation("root_user_to_document_root_permission", fields: [documentRootId], references: [id], onDelete: Cascade)
+  user                         User                           @relation("root_user_to_user_permission", fields: [userId], references: [id], onDelete: Cascade)
+  view_DocumentUserPermissions view_DocumentUserPermissions[]
 
-  user   User   @relation("root_user_to_user_permission", fields: [userId], references: [id], onDelete: Cascade)
-  userId String @map("user_id") @db.Uuid
-
-  documentRoot   DocumentRoot @relation("root_user_to_document_root_permission", fields: [documentRootId], references: [id], onDelete: Cascade)
-  documentRootId String       @map("document_root_id") @db.Uuid
-
+  @@index([documentRootId], map: "root_user_permissions_document_root_id_index")
+  @@index([userId], map: "root_user_permissions_user_id_index")
   @@map("root_user_permissions")
 }
 
@@ -127,6 +115,26 @@ model Sessions {
 
   @@index([expire], map: "IDX_session_expire")
   @@map("sessions")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view view_DocumentUserPermissions {
+  documentRootId        String               @map("document_root_id") @db.Uuid
+  userId                String               @map("user_id") @db.Uuid
+  access                Access               @map("access")
+  documentId            String               @map("document_id") @db.Uuid
+  rootUserPermissionId  String?              @map("root_user_permission_id") @db.Uuid
+  rootGroupPermissionId String?              @map("root_group_permission_id") @db.Uuid
+  groupId               String?              @map("group_id") @db.Uuid
+  documentRoot          DocumentRoot         @relation(fields: [documentRootId], references: [id])
+  user                  User                 @relation(fields: [userId], references: [id])
+  document              Document             @relation(fields: [documentId], references: [id])
+  rootUserPermission    RootUserPermission?  @relation(fields: [rootUserPermissionId], references: [id])
+  rootGroupPermission   RootGroupPermission? @relation(fields: [rootGroupPermissionId], references: [id])
+  group                 StudentGroup?        @relation(fields: [groupId], references: [id])
+
+  @@unique([documentRootId, userId, access, documentId])
+  @@map("view__document_user_permissions")
 }
 
 enum Access {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,13 +108,11 @@ model RootUserPermission {
   @@map("root_user_permissions")
 }
 
-model Sessions {
-  sid    String   @id @db.VarChar
-  sess   Json     @db.Json
-  expire DateTime @db.Timestamp(6)
-
-  @@index([expire], map: "IDX_session_expire")
-  @@map("sessions")
+model Session {
+  id        String   @id
+  sid       String   @unique
+  data      String
+  expiresAt   DateTime
 }
 
 /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ datasource db {
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["views", "postgresqlExtensions"]
+  previewFeatures = ["views", "postgresqlExtensions", "relationJoins"]
 }
 
 generator docs {

--- a/prisma/views/public/view_DocumentUserPermissions.sql
+++ b/prisma/views/public/view_DocumentUserPermissions.sql
@@ -1,0 +1,129 @@
+SELECT
+  DISTINCT ranked_permissions.document_root_id,
+  ranked_permissions.user_id,
+  ranked_permissions.access,
+  ranked_permissions.document_id,
+  ranked_permissions.root_user_permission_id,
+  ranked_permissions.root_group_permission_id,
+  ranked_permissions.group_id
+FROM
+  (
+    SELECT
+      document_user_permissions.document_root_id,
+      document_user_permissions.user_id,
+      document_user_permissions.access,
+      document_user_permissions.document_id,
+      document_user_permissions.root_user_permission_id,
+      document_user_permissions.root_group_permission_id,
+      document_user_permissions.group_id,
+      row_number() OVER (
+        PARTITION BY document_user_permissions.document_root_id,
+        document_user_permissions.user_id
+        ORDER BY
+          document_user_permissions.access DESC
+      ) AS rn
+    FROM
+      (
+        SELECT
+          document_roots.id AS document_root_id,
+          documents.author_id AS user_id,
+          document_roots.access,
+          documents.id AS document_id,
+          NULL :: uuid AS root_user_permission_id,
+          NULL :: uuid AS root_group_permission_id,
+          NULL :: uuid AS group_id
+        FROM
+          (
+            document_roots
+            JOIN documents ON ((document_roots.id = documents.document_root_id))
+          )
+        UNION
+        SELECT
+          document_roots.id AS document_root_id,
+          rup.user_id,
+          rup.access,
+          documents.id AS document_id,
+          rup.id AS root_user_permission_id,
+          NULL :: uuid AS root_group_permission_id,
+          NULL :: uuid AS group_id
+        FROM
+          (
+            (
+              document_roots
+              JOIN documents ON ((document_roots.id = documents.document_root_id))
+            )
+            JOIN root_user_permissions rup ON (
+              (
+                (document_roots.id = rup.document_root_id)
+                AND (
+                  (documents.author_id = rup.user_id)
+                  OR (rup.access >= document_roots.shared_access)
+                )
+              )
+            )
+          )
+        UNION
+        SELECT
+          document_roots.id AS document_root_id,
+          documents.author_id AS user_id,
+          rgp.access,
+          documents.id AS document_id,
+          NULL :: uuid AS root_user_permission_id,
+          rgp.id AS root_group_permission_id,
+          sg.id AS group_id
+        FROM
+          (
+            (
+              (
+                (
+                  document_roots
+                  JOIN documents ON ((documents.document_root_id = document_roots.id))
+                )
+                JOIN root_group_permissions rgp ON ((document_roots.id = rgp.document_root_id))
+              )
+              JOIN student_groups sg ON ((rgp.student_group_id = sg.id))
+            )
+            JOIN "_StudentGroupToUser" sg_to_user ON (
+              (
+                (sg_to_user."A" = sg.id)
+                AND (sg_to_user."B" = documents.author_id)
+              )
+            )
+          )
+        UNION
+        SELECT
+          document_roots.id AS document_root_id,
+          sg_to_user."B" AS user_id,
+          rgp.access,
+          documents.id AS document_id,
+          NULL :: uuid AS root_user_permission_id,
+          rgp.id AS root_group_permission_id,
+          sg.id AS group_id
+        FROM
+          (
+            (
+              (
+                (
+                  document_roots
+                  JOIN documents ON ((document_roots.id = documents.document_root_id))
+                )
+                JOIN root_group_permissions rgp ON (
+                  (
+                    (document_roots.id = rgp.document_root_id)
+                    AND (rgp.access >= document_roots.shared_access)
+                  )
+                )
+              )
+              JOIN student_groups sg ON ((rgp.student_group_id = sg.id))
+            )
+            JOIN "_StudentGroupToUser" sg_to_user ON (
+              (
+                (sg_to_user."A" = sg.id)
+                AND (sg_to_user."B" <> documents.author_id)
+              )
+            )
+          )
+      ) document_user_permissions
+  ) ranked_permissions
+WHERE
+  (ranked_permissions.rn = 1);

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -6,7 +6,8 @@ import {
     PrismaClient,
     RootGroupPermission,
     RootUserPermission,
-    User
+    User,
+    view_DocumentUserPermissions
 } from '@prisma/client';
 import { ApiDocument, prepareDocument } from './Document';
 import { ApiUserPermission } from './RootUserPermission';
@@ -70,6 +71,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
             if (!documentRoot) {
                 return null;
             }
+
             const documents = await prisma.view_DocumentUserPermissions.findMany({
                 where: {
                     userId: actor.id,
@@ -79,7 +81,8 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
                 },
                 include: {
                     document: true
-                }
+                },
+                relationLoadStrategy: 'query'
             });
 
             return {

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -60,18 +60,16 @@ const prepareUserPermission = (permission: RootUserPermission): ApiUserPermissio
     };
 };
 
-const asApiRecord = (
-    dbResult:
-        | (DbDocumentRoot & {
-              view_DocumentUserPermissions: (view_DocumentUserPermissions & { document: Document })[];
-          })
-        | null
-): ApiDocumentRoot | null => {
+type DocumentRootWithDocuments = DbDocumentRoot & {
+    view_DocumentUserPermissions: (view_DocumentUserPermissions & { document: Document })[];
+};
+
+const asApiRecord = (dbResult: DocumentRootWithDocuments | null): ApiDocumentRoot | null => {
     if (!dbResult) {
         return null;
     }
 
-    return {
+    const result: ApiDocumentRoot = {
         ...dbResult,
         userPermissions: dbResult.view_DocumentUserPermissions
             .filter((d) => !!d.rootUserPermissionId)
@@ -83,6 +81,8 @@ const asApiRecord = (
             d.access === Access.None ? { ...d.document, data: null } : d.document
         )
     };
+    delete (result as Partial<DocumentRootWithDocuments>).view_DocumentUserPermissions;
+    return result;
 };
 
 function DocumentRoot(db: PrismaClient['documentRoot']) {

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -5,10 +5,28 @@ import { createDataExtractor } from '../helpers/dataExtractor';
 
 const getData = createDataExtractor<Prisma.StudentGroupUncheckedUpdateInput>(['description', 'name']);
 
+type ApiStudentGroup = DbStudentGroup & {
+    userIds: string[];
+};
+
+const asApiRecord = (
+    record: (DbStudentGroup & { users: { id: string }[] }) | null
+): ApiStudentGroup | null => {
+    if (!record) {
+        return null;
+    }
+    const group = {
+        ...record,
+        userIds: record.users.map((user) => user.id)
+    };
+    delete (group as any).users;
+    return group;
+};
+
 function StudentGroup(db: PrismaClient['studentGroup']) {
     return Object.assign(db, {
-        async findModel(id: string): Promise<DbStudentGroup | null> {
-            return db.findUnique({
+        async findModel(id: string): Promise<ApiStudentGroup | null> {
+            const model = await db.findUnique({
                 where: {
                     id: id
                 },
@@ -20,6 +38,7 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                     }
                 }
             });
+            return asApiRecord(model);
         },
 
         async updateModel(actor: User, id: string, data: Partial<DbStudentGroup>): Promise<DbStudentGroup> {
@@ -40,23 +59,24 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
             });
         },
 
-        async all(actor: User): Promise<DbStudentGroup[]> {
+        async all(actor: User): Promise<ApiStudentGroup[]> {
             // TODO: Does this behaviour make sense?
             //  Yes, it might be useful (a) for an admin to get all groups, and (b) for a user or admin to get all
             //  groups containing a specific user. However, this method now combines two separate behaviors and can't
             //  be used to get the groups that an admin is part of (which may not be required, but the behavior is still
             //  somewhat unexpected). Also, do we want to return the user IDs or not?
-            if (actor.isAdmin) {
-                return db.findMany({});
-            }
-            return db.findMany({
-                where: {
-                    users: {
-                        some: {
-                            id: actor.id
-                        }
-                    }
-                },
+            //
+            // user IDs should be provided, otherwise the frontend will not be able to relate the groups to the users
+            const all = await db.findMany({
+                where: actor.isAdmin
+                    ? undefined
+                    : {
+                          users: {
+                              some: {
+                                  id: actor.id
+                              }
+                          }
+                      },
                 include: {
                     users: {
                         select: {
@@ -65,6 +85,7 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                     }
                 }
             });
+            return all.map((group) => asApiRecord(group)!);
         },
 
         async createModel(

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,31 +1,33 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 
-const options: Prisma.PrismaClientOptions & {log: (Prisma.LogDefinition | {emit: 'event', level: 'query'})[]} = {} as any;
+const options: Prisma.PrismaClientOptions & {
+    log: (Prisma.LogDefinition | { emit: 'event'; level: 'query' })[];
+} = {} as any;
 if (process.env.LOG) {
     options.log = [
         {
-          emit: 'event',
-          level: 'query',
+            emit: 'event',
+            level: 'query'
         },
         {
-          emit: 'stdout',
-          level: 'error',
+            emit: 'stdout',
+            level: 'error'
         },
         {
-          emit: 'stdout',
-          level: 'info',
+            emit: 'stdout',
+            level: 'info'
         },
         {
-          emit: 'stdout',
-          level: 'warn',
-        },
-      ];
+            emit: 'stdout',
+            level: 'warn'
+        }
+    ];
 }
 const prisma = new PrismaClient(options);
 
 if (process.env.LOG) {
     prisma.$on('query', (e) => {
-        console.log(`Query: ${e.query}; ${e.params.slice(0, 120)}; -- ${e.duration}ms`)
+        console.log(`Query: ${e.query}; ${e.params.slice(0, 120)}; -- ${e.duration}ms`);
     });
 }
 

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -24,6 +24,7 @@ if (process.env.LOG) {
     ];
 }
 const prisma = new PrismaClient(options);
+prisma.$connect();
 
 if (process.env.LOG) {
     prisma.$on('query', (e) => {

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,9 +1,32 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 
-const options: Prisma.PrismaClientOptions = {};
+const options: Prisma.PrismaClientOptions & {log: (Prisma.LogDefinition | {emit: 'event', level: 'query'})[]} = {} as any;
 if (process.env.LOG) {
-    options.log = ['query', 'info', 'warn'];
+    options.log = [
+        {
+          emit: 'event',
+          level: 'query',
+        },
+        {
+          emit: 'stdout',
+          level: 'error',
+        },
+        {
+          emit: 'stdout',
+          level: 'info',
+        },
+        {
+          emit: 'stdout',
+          level: 'warn',
+        },
+      ];
 }
 const prisma = new PrismaClient(options);
+
+if (process.env.LOG) {
+    prisma.$on('query', (e) => {
+        console.log(`Query: ${e.query}; ${e.params.slice(0, 120)}; -- ${e.duration}ms`)
+    });
+}
 
 export default prisma;

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,11 @@
     mermaid "^10.8.0"
     puppeteer "^19.0.0"
 
+"@noble/hashes@^1.1.5":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -109,6 +114,13 @@
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f"
   integrity sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==
+
+"@paralleldrive/cuid2@^2.2.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz#7f91364d53b89e2c9cb9e02e8dd0f129e834455f"
+  integrity sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
 
 "@prisma/client@^5.16.1":
   version "5.16.1"
@@ -411,6 +423,15 @@
     unbzip2-stream "1.4.3"
     yargs "17.7.1"
 
+"@quixo3/prisma-session-store@^3.1.13":
+  version "3.1.13"
+  resolved "https://registry.yarnpkg.com/@quixo3/prisma-session-store/-/prisma-session-store-3.1.13.tgz#a4adef5455102d12897c7fdada0158156c31a262"
+  integrity sha512-EAuOvYAaAsQ0OqxkdJG/Qs3cxlT4VV8SFHjtsA3G01uB1b6r7xftX3oeg7mcG0HN/DI1qOqwvy3YFoJ38ls0iA==
+  dependencies:
+    "@paralleldrive/cuid2" "^2.2.0"
+    ts-dedent "^2.2.0"
+    type-fest "^2.5.2"
+
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
@@ -443,15 +464,6 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
-
-"@types/connect-pg-simple@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/connect-pg-simple/-/connect-pg-simple-7.0.3.tgz#05b4bdbccbba333787b01730bacd202f15afa480"
-  integrity sha512-NGCy9WBlW2bw+J/QlLnFZ9WjoGs6tMo3LAut6mY4kK+XHzue//lpNVpAvYRpIwM969vBRAM2Re0izUvV6kt+NA==
-  dependencies:
-    "@types/express" "*"
-    "@types/express-session" "*"
-    "@types/pg" "*"
 
 "@types/connect@*":
   version "3.4.38"
@@ -520,7 +532,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express-session@*":
+"@types/express-session@^1.18.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@types/express-session/-/express-session-1.18.0.tgz#7c6f25c3604b28d6bc08a2e3929997bbc7672fa2"
   integrity sha512-27JdDRgor6PoYlURY+Y5kCakqp5ulC0kmf7y+QwaY+hv9jEFuQOThgkjyA53RP3jmKuBsH5GR6qEfFmvb8mwOA==
@@ -616,15 +628,6 @@
   integrity sha512-FD0qD5hbPWQzaM0wHUnJ/T0BBCJBxCeemtnCwc/ThhTg3x9jfrAcRUmj5Dopza+MfFS9acTe3wk7rcVnRIp/0A==
   dependencies:
     "@types/express" "*"
-
-"@types/pg@*":
-  version "8.11.6"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.11.6.tgz#a2d0fb0a14b53951a17df5197401569fb9c0c54b"
-  integrity sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==
-  dependencies:
-    "@types/node" "*"
-    pg-protocol "*"
-    pg-types "^4.0.1"
 
 "@types/qs@*":
   version "6.9.15"
@@ -1170,13 +1173,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
-
-connect-pg-simple@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/connect-pg-simple/-/connect-pg-simple-9.0.1.tgz#98637ff17a5bfeaeef638093fcf484bc96fcbbf6"
-  integrity sha512-BuwWJH3K3aLpONkO9s12WhZ9ceMjIBxIJAh0JD9x4z1Y9nShmWqZvge5PG/+4j2cIOcguUoa2PSQ4HO/oTsrVg==
-  dependencies:
-    pg "^8.8.0"
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -3202,11 +3198,6 @@ object-inspect@^1.13.1:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
 
-obuf@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
-  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
-
 on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -3422,80 +3413,6 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-pg-cloudflare@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
-  integrity sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==
-
-pg-connection-string@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.6.4.tgz#f543862adfa49fa4e14bc8a8892d2a84d754246d"
-  integrity sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA==
-
-pg-int8@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
-  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
-
-pg-numeric@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pg-numeric/-/pg-numeric-1.0.2.tgz#816d9a44026086ae8ae74839acd6a09b0636aa3a"
-  integrity sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==
-
-pg-pool@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.6.2.tgz#3a592370b8ae3f02a7c8130d245bc02fa2c5f3f2"
-  integrity sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==
-
-pg-protocol@*, pg-protocol@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.1.tgz#21333e6d83b01faaebfe7a33a7ad6bfd9ed38cb3"
-  integrity sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==
-
-pg-types@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
-  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
-  dependencies:
-    pg-int8 "1.0.1"
-    postgres-array "~2.0.0"
-    postgres-bytea "~1.0.0"
-    postgres-date "~1.0.4"
-    postgres-interval "^1.1.0"
-
-pg-types@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-4.0.2.tgz#399209a57c326f162461faa870145bb0f918b76d"
-  integrity sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==
-  dependencies:
-    pg-int8 "1.0.1"
-    pg-numeric "1.0.2"
-    postgres-array "~3.0.1"
-    postgres-bytea "~3.0.0"
-    postgres-date "~2.1.0"
-    postgres-interval "^3.0.0"
-    postgres-range "^1.1.1"
-
-pg@^8.8.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-8.12.0.tgz#9341724db571022490b657908f65aee8db91df79"
-  integrity sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==
-  dependencies:
-    pg-connection-string "^2.6.4"
-    pg-pool "^3.6.2"
-    pg-protocol "^1.6.1"
-    pg-types "^2.1.0"
-    pgpass "1.x"
-  optionalDependencies:
-    pg-cloudflare "^1.1.1"
-
-pgpass@1.x:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
-  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
-  dependencies:
-    split2 "^4.1.0"
-
 picocolors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
@@ -3517,55 +3434,6 @@ pluralize@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
-
-postgres-array@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
-  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
-
-postgres-array@~3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-3.0.2.tgz#68d6182cb0f7f152a7e60dc6a6889ed74b0a5f98"
-  integrity sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==
-
-postgres-bytea@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
-  integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
-
-postgres-bytea@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-3.0.0.tgz#9048dc461ac7ba70a6a42d109221619ecd1cb089"
-  integrity sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==
-  dependencies:
-    obuf "~1.1.2"
-
-postgres-date@~1.0.4:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
-  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
-
-postgres-date@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-2.1.0.tgz#b85d3c1fb6fb3c6c8db1e9942a13a3bf625189d0"
-  integrity sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==
-
-postgres-interval@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
-  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
-  dependencies:
-    xtend "^4.0.0"
-
-postgres-interval@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-3.0.0.tgz#baf7a8b3ebab19b7f38f07566c7aab0962f0c86a"
-  integrity sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==
-
-postgres-range@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/postgres-range/-/postgres-range-1.1.4.tgz#a59c5f9520909bcec5e63e8cf913a92e4c952863"
-  integrity sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==
 
 prettier@^3.3.2:
   version "3.3.2"
@@ -4076,11 +3944,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz#22aa922dcf2f2885a6494a261f2d8b75345d0326"
   integrity sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==
 
-split2@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
-  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
-
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
@@ -4334,6 +4197,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.5.2:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -4528,11 +4396,6 @@ ws@~8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
-
-xtend@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,10 +122,10 @@
   dependencies:
     "@noble/hashes" "^1.1.5"
 
-"@prisma/client@^5.16.1":
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.16.1.tgz#65c5649b4701c097e7fa943c91a3140ce8bf053d"
-  integrity sha512-wM9SKQjF0qLxdnOZIVAIMKiz6Hu7vDt4FFAih85K1dk/Rr2mdahy6d3QP41K62N9O0DJJA//gUDA3Mp49xsKIg==
+"@prisma/client@^5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.18.0.tgz#526e4281a448f214c0ff81d65c39243608c98294"
+  integrity sha512-BWivkLh+af1kqC89zCJYkHsRcyWsM8/JHpsDMM76DjP3ZdEquJhXa4IeX+HkWPnwJ5FanxEJFZZDTWiDs/Kvyw==
 
 "@prisma/debug@4.16.2":
   version "4.16.2"
@@ -150,15 +150,15 @@
   resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.15.0.tgz#a4c1d8dbca9cf29aab1c82a56a65224ed3e05f13"
   integrity sha512-QpEAOjieLPc/4sMny/WrWqtpIAmBYsgqwWlWwIctqZO0AbhQ9QcT6x2Ut3ojbDo/pFRCCA1Z1+xm2MUy7fAkZA==
 
-"@prisma/debug@5.16.1":
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.16.1.tgz#4887a57a0973fb732a60c30dc48de97bf1eefd7e"
-  integrity sha512-JsNgZAg6BD9RInLSrg7ZYzo11N7cVvYArq3fHGSD89HSgtN0VDdjV6bib7YddbcO6snzjchTiLfjeTqBjtArVQ==
+"@prisma/debug@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.18.0.tgz#527799e044d2903a35945e61ac2d8916e4b61ead"
+  integrity sha512-f+ZvpTLidSo3LMJxQPVgAxdAjzv5OpzAo/eF8qZqbwvgi2F5cTOI9XCpdRzJYA0iGfajjwjOKKrVq64vkxEfUw==
 
-"@prisma/engines-version@5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303":
-  version "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303.tgz#63ceebefb7daa1eb17f250cad75d35999a50ee1b"
-  integrity sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw==
+"@prisma/engines-version@5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169":
+  version "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz#203426ebf4ec4e1acce7da4a59ec8f0df92b29e7"
+  integrity sha512-a/+LpJj8vYU3nmtkg+N3X51ddbt35yYrRe8wqHTJtYQt7l1f8kjIBcCs6sHJvodW/EK5XGvboOiwm47fmNrbgg==
 
 "@prisma/engines@4.16.2":
   version "4.16.2"
@@ -170,15 +170,15 @@
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.0.0.tgz#5249650eabe77c458c90f2be97d8210353c2e22e"
   integrity sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==
 
-"@prisma/engines@5.16.1":
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.16.1.tgz#a14e5d08d34241ed1f1bb7d11ed44eacb37b6fc6"
-  integrity sha512-KkyF3eIUtBIyp5A/rJHCtwQO18OjpGgx18PzjyGcJDY/+vNgaVyuVd+TgwBgeq6NLdd1XMwRCI+58vinHsAdfA==
+"@prisma/engines@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.18.0.tgz#26ea46e26498be622407cf95663d7fb4c39c895b"
+  integrity sha512-ofmpGLeJ2q2P0wa/XaEgTnX/IsLnvSp/gZts0zjgLNdBhfuj2lowOOPmDcfKljLQUXMvAek3lw5T01kHmCG8rg==
   dependencies:
-    "@prisma/debug" "5.16.1"
-    "@prisma/engines-version" "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303"
-    "@prisma/fetch-engine" "5.16.1"
-    "@prisma/get-platform" "5.16.1"
+    "@prisma/debug" "5.18.0"
+    "@prisma/engines-version" "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169"
+    "@prisma/fetch-engine" "5.18.0"
+    "@prisma/get-platform" "5.18.0"
 
 "@prisma/fetch-engine@4.16.2":
   version "4.16.2"
@@ -226,14 +226,14 @@
     temp-dir "2.0.0"
     tempy "1.0.1"
 
-"@prisma/fetch-engine@5.16.1":
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.16.1.tgz#506a034eb23222af27ba635eb48c63df0ba7fc14"
-  integrity sha512-oOkjaPU1lhcA/Rvr4GVfd1NLJBwExgNBE36Ueq7dr71kTMwy++a3U3oLd2ZwrV9dj9xoP6LjCcky799D9nEt4w==
+"@prisma/fetch-engine@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.18.0.tgz#5b343e2b36b27e2713901ddd032ddd6932b3d55f"
+  integrity sha512-I/3u0x2n31rGaAuBRx2YK4eB7R/1zCuayo2DGwSpGyrJWsZesrV7QVw7ND0/Suxeo/vLkJ5OwuBqHoCxvTHpOg==
   dependencies:
-    "@prisma/debug" "5.16.1"
-    "@prisma/engines-version" "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303"
-    "@prisma/get-platform" "5.16.1"
+    "@prisma/debug" "5.18.0"
+    "@prisma/engines-version" "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169"
+    "@prisma/get-platform" "5.18.0"
 
 "@prisma/generator-helper@4.16.2", "@prisma/generator-helper@^4.14.0":
   version "4.16.2"
@@ -294,12 +294,12 @@
     terminal-link "2.1.1"
     ts-pattern "4.3.0"
 
-"@prisma/get-platform@5.16.1":
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.16.1.tgz#613197c58acaafd5142d48a11f4df45a8f26a9e9"
-  integrity sha512-R4IKnWnMkR2nUAbU5gjrPehdQYUUd7RENFD2/D+xXTNhcqczp0N+WEGQ3ViyI3+6mtVcjjNIMdnUTNyu3GxIgA==
+"@prisma/get-platform@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.18.0.tgz#0dc4c82fe9a4971f4519a57cb2dd69d8e0df4b71"
+  integrity sha512-Tk+m7+uhqcKDgnMnFN0lRiH7Ewea0OEsZZs9pqXa7i3+7svS3FSCqDBCaM9x5fmhhkufiG0BtunJVDka+46DlA==
   dependencies:
-    "@prisma/debug" "5.16.1"
+    "@prisma/debug" "5.18.0"
 
 "@prisma/internals@5.0.0":
   version "5.0.0"
@@ -3472,12 +3472,12 @@ prisma-erd-generator@^1.11.2:
     "@prisma/generator-helper" "^4.0.0 || ^5.0.0"
     dotenv "^16.3.1"
 
-prisma@^5.16.1:
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.16.1.tgz#6dfd1e27e6534741326f4a231f04c16b3fbb7ba9"
-  integrity sha512-Z1Uqodk44diztImxALgJJfNl2Uisl9xDRvqybMKEBYJLNKNhDfAHf+ZIJbZyYiBhLMbKU9cYGdDVG5IIXEnL2Q==
+prisma@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.18.0.tgz#5ef69c802a075b7596231ea57003496873610b9e"
+  integrity sha512-+TrSIxZsh64OPOmaSgVPH7ALL9dfU0jceYaMJXsNrTkFHO7/3RANi5K2ZiPB1De9+KDxCWn7jvRq8y8pvk+o9g==
   dependencies:
-    "@prisma/engines" "5.16.1"
+    "@prisma/engines" "5.18.0"
 
 prismjs@^1.29.0:
   version "1.29.0"


### PR DESCRIPTION
> [!NOTE]  
> - prisma query duration dropped from ~3.8s to ~30ms
> - new view `view_DocumentUserPermissions`
> - can be used as a normal Prisma Model, including all the `where`, `include` and `select` stuff
> - should be executed with `relationLoadStrategy='query'`, otherwise there is a big performance impact

With the introduction of a view, the query to gather all documents which a user has access to (either because he is the author and the doc root gives him access, or because he has granted a user permission or because he has permission through a student group).
The view has 4 parts that are then combined by a union:
- get all documents where the user is the author
- get all documents where 
  - the user has been granted shared access or
  - the authors access has been extended by a user permissions
- all group-based permissions for the documents author
- all group based permissions for a user, which is not the author (--> shared access policy)

The union is sorted by the highest permission and the first record is then returned in the view.

So the view is a table with the db structure

| document_root_id        | user_id           | access | document_id        | root_user_permission_id  | root_group_permission_id  | group_id          |
|:------------------------|:------------------|:-------|:-------------------|:-------------------------|:--------------------------|:------------------|
| `07ad...`              | `f34f...`         | `RW`     | `e9b8...`          | `c3ec...`                | `2ace...`                 | `09e8...`         |

Prisma-ORM can then relate the fields to it's records.

Important note: the `relationLoadStrategy` must be set to `query`, otherwise there is a huge performance impact.