### PR TITLE
Minor dev fixes

### DIFF
--- a/.idea/runConfigurations/dev.xml
+++ b/.idea/runConfigurations/dev.xml
@@ -6,9 +6,7 @@
       <script value="dev" />
     </scripts>
     <node-interpreter value="project" />
-    <envs>
-      <env name="DATABASE_URL" value="postgresql://teaching_website_backend:zW4SMEXLHpXXxxk@localhost:5432/teaching_website?schema=public" />
-    </envs>
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker compose --file dev_services.compose.yml up
 to start the dev services.
 
 #### Postgres
-`docker-compose` rebuilds the container PostgreSQL container on restart. When building the container, all files in `db/docker/sql` are copied to `/docker-entrypoint-initdb.d/`. They are executed by PostgreSQL **only** if **no volume exists** yet. These init files reflect the expected database setup for a production deployment, including a dedicated user for the backend.
+`docker compose` rebuilds the container PostgreSQL container on restart. When building the container, all files in `db/docker/sql` are copied to `/docker-entrypoint-initdb.d/`. They are executed by PostgreSQL **only** if **no volume exists** yet. These init files reflect the expected database setup for a production deployment, including a dedicated user for the backend.
 
 The `db/scripts` directory contains files for purging the DB. Volumes stay intact, which means that the aforementioned init scripts will not be run again. 
 

--- a/scripts/purge_dev_services.sh
+++ b/scripts/purge_dev_services.sh
@@ -5,5 +5,5 @@ COMPOSE_FILE="dev_services.compose.yml"
 # Ensure we are in the right directory
 ls "$COMPOSE_FILE" &> /dev/null || (echo "Run from repository root!" && exit 1)
 
-docker-compose -f "$COMPOSE_FILE" down -v
-docker-compose -f "$COMPOSE_FILE" rm
+docker compose -f "$COMPOSE_FILE" down -v
+docker compose -f "$COMPOSE_FILE" rm


### PR DESCRIPTION
- Remove outdated hard-coded env from IntelliJ run config.
- Update dev services script (and README): `docker-compose` is now `docker compose` on the latest version of Docker Desktop.