### PR TITLE
[feature] emit updates on io rooms

### DIFF
--- a/src/routes/socketEventTypes.ts
+++ b/src/routes/socketEventTypes.ts
@@ -9,7 +9,8 @@ export enum IoEvent {
     CHANGED_RECORD = 'CHANGED_RECORD',
     CHANGED_DOCUMENT = 'CHANGED_DOCUMENT',
     DELETED_RECORD = 'DELETED_RECORD',
-    CONNECTED_CLIENTS = 'CONNECTED_CLIENTS'
+    CONNECTED_CLIENTS = 'CONNECTED_CLIENTS',
+    ROOMS = 'ROOMS'
 }
 
 export enum RecordType {
@@ -47,6 +48,11 @@ export interface ChangedDocument {
 export interface ConnectedClients {
     room: string;
     count: number;
+}
+
+export interface IoRooms {
+    rooms: [string, number][];
+    type: 'full' | 'update';
 }
 
 export interface DeletedRecord {
@@ -98,6 +104,7 @@ export type ServerToClientEvents = {
     [IoEvent.DELETED_RECORD]: (message: DeletedRecord) => void;
     [IoEvent.CHANGED_DOCUMENT]: (message: ChangedDocument) => void;
     [IoEvent.CONNECTED_CLIENTS]: (message: ConnectedClients) => void;
+    [IoEvent.ROOMS]: (message: IoRooms) => void;
 };
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
Admins shall see how many clients are connected per user.
- on admin connection, emit a `full` overview
- on join/leave send a `update`

Since each user connects to it's own id, we simply deliver `roomId -> size` messages. To ensure an easy conversion to a js Map<string, number>, the message `IoEvent.ROOMS` has the following signature:

```ts
export interface IoRooms {
    rooms: [string, number][];
    type: 'full' | 'update';
}
```

In the Frontend, the Map can be created as follows:

```tsx
const idSizeMap = new Map(message.rooms);
``` 


