### PR TITLE
fix: notify all on shared access

### DIFF
--- a/src/helpers/accessPolicy.ts
+++ b/src/helpers/accessPolicy.ts
@@ -15,6 +15,10 @@ export const ROAccess = new Set<Access | undefined>([
     Access.RO_User,
     Access.RO_StudentGroup
 ]);
+export const RO_RW_DocumentRootAccess = new Set<Access | undefined>([
+    Access.RO_DocumentRoot,
+    Access.RW_DocumentRoot
+]);
 
 export const AccessLevels = new Map<Access, number>([
     [Access.RO_DocumentRoot, 0],

--- a/src/models/Document.ts
+++ b/src/models/Document.ts
@@ -56,6 +56,7 @@ type Response<T> = {
     model: T;
     permissions: {
         access: Access;
+        sharedAccess: Access;
         group: ApiGroupPermission[];
         user: ApiUserPermission[];
     };
@@ -160,6 +161,7 @@ function Document(db: PrismaClient['document']) {
                 model: model.document,
                 permissions: {
                     access: documentRoot.access,
+                    sharedAccess: documentRoot.sharedAccess,
                     group: documentRoot.groupPermissions,
                     user: documentRoot.userPermissions
                 }

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -39,6 +39,7 @@ export type AccessCheckableDocumentRootWithDocuments = AccessCheckableDocumentRo
 
 export interface Config {
     access?: Access; // Access level of document root
+    sharedAccess?: Access; // Access level of shared documents
     userPermissions?: Omit<ApiUserPermission, 'id'>[];
     groupPermissions?: Omit<ApiGroupPermission, 'id'>[];
 }
@@ -147,6 +148,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
                 data: {
                     id: id,
                     access: asDocumentRootAccess(config.access),
+                    sharedAccess: config.sharedAccess || Access.None_DocumentRoot,
                     /* 0 is falsey in JS (since TS strictNullChecks is on, `grouPermissions?.length > 0` is not valid) */
                     rootGroupPermissions: config.groupPermissions?.length
                         ? {


### PR DESCRIPTION
Follow up of #23 

ensure connected clients are notified when a shared document is created/updated/deleted