### PR TITLE
feature: api delete for root documents

### DIFF
--- a/prisma/migrations/20241118183039_fix_shared_access_in_view__all_document_user_permissions/migration.sql
+++ b/prisma/migrations/20241118183039_fix_shared_access_in_view__all_document_user_permissions/migration.sql
@@ -1,0 +1,181 @@
+
+CREATE OR REPLACE VIEW view__all_document_user_permissions AS
+    SELECT
+        document_root_id,
+        user_id,
+        access,
+        document_id,
+        root_user_permission_id,
+        root_group_permission_id,
+        group_id,
+        ROW_NUMBER() OVER (PARTITION BY document_root_id, user_id, document_id ORDER BY access DESC) AS access_rank
+    FROM (
+            -- get all documents where the user **is the author**
+            -- including all child documents
+            WITH RECURSIVE 
+                document_hierarchy AS (
+                    -- Anchor member: select the root document
+                    SELECT
+                        document_roots.id AS document_root_id,
+                        documents.id AS document_id,
+                        documents.author_id AS user_id,
+                        document_roots.access AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        document_roots
+                        INNER JOIN documents ON document_roots.id = documents.document_root_id
+                    WHERE documents.parent_id IS NULL  -- Assuming root documents have parent_id as NULL
+
+                    UNION ALL -- keeps duplicates in the result set
+
+                    -- Recursive member: select child documents with the parent's author as the user 
+                    SELECT
+                        document_hierarchy.document_root_id AS document_root_id,
+                        child_documents.id AS document_id,
+                        document_hierarchy.user_id AS user_id,
+                        document_hierarchy.access AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        document_hierarchy
+                        INNER JOIN documents AS child_documents ON document_hierarchy.document_id = child_documents.parent_id
+                ), 
+                -- get all documents where the user is **not the author**
+                -- but has been granted **shared access**
+                shared_doc_hierarchy AS (
+                    -- Anchor member: select the root document
+                    SELECT
+                        document_roots.id AS document_root_id,
+                        documents.id AS document_id,
+                        all_users.id AS user_id,
+                        CASE 
+                            WHEN document_roots.shared_access <= document_roots.access THEN document_roots.shared_access
+                            ELSE document_roots.access
+                        END AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        document_roots
+                        INNER JOIN documents ON document_roots.id = documents.document_root_id
+                        CROSS JOIN users all_users
+                    WHERE documents.parent_id IS NULL  -- Assuming root documents have parent_id as NULL
+                        AND documents.author_id != all_users.id
+                        AND document_roots.access != 'None_DocumentRoot'
+                        AND (
+                            document_roots.shared_access='RO_DocumentRoot' 
+                            OR
+                            document_roots.shared_access='RW_DocumentRoot'
+                        )
+
+                    UNION ALL -- keeps duplicates in the result set
+
+                    -- Recursive member: select child documents with the parent's author as the user 
+                    SELECT
+                        shared_doc_hierarchy.document_root_id AS document_root_id,
+                        child_documents.id AS document_id,
+                        shared_doc_hierarchy.user_id AS user_id,
+                        shared_doc_hierarchy.access AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        shared_doc_hierarchy
+                        INNER JOIN documents AS child_documents ON shared_doc_hierarchy.document_id = child_documents.parent_id
+                ) 
+            SELECT 
+                document_root_id,
+                user_id,
+                access,
+                document_id,
+                root_user_permission_id,
+                root_group_permission_id,
+                group_id
+            FROM document_hierarchy
+        UNION ALL
+            SELECT 
+                document_root_id,
+                user_id,
+                access,
+                document_id,
+                root_user_permission_id,
+                root_group_permission_id,
+                group_id
+            FROM shared_doc_hierarchy
+        UNION ALL
+            -- get all documents where the user has been granted shared access
+            -- or the access has been extended by user permissions
+            SELECT
+                document_roots.id AS document_root_id,
+                rup.user_id AS user_id,
+                rup.access AS access,
+                documents.id AS document_id,
+                rup.id AS root_user_permission_id,
+                NULL::uuid AS root_group_permission_id,
+                NULL::uuid AS group_id
+            FROM 
+                document_roots
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN root_user_permissions rup 
+                    ON (
+                        document_roots.id = rup.document_root_id 
+                        AND (
+                            documents.author_id = rup.user_id
+                            OR
+                            rup.access >= document_roots.shared_access
+                        )
+                    )
+            WHERE rup.user_id IS NOT NULL
+        UNION ALL
+            -- all group-based permissions for the documents author
+            SELECT
+                document_roots.id AS document_root_id,
+                sg_to_user."B" AS user_id,
+                rgp.access AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                rgp.id AS root_group_permission_id,
+                sg.id AS group_id
+            FROM 
+                document_roots
+                INNER JOIN root_group_permissions rgp ON document_roots.id=rgp.document_root_id
+                INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN "_StudentGroupToUser" sg_to_user 
+                    ON (
+                        sg_to_user."A"=sg.id 
+                        AND (
+                            sg_to_user."B"=documents.author_id
+                            OR documents.author_id is null
+                        )
+                    )
+            WHERE sg_to_user."B" IS NOT NULL
+        UNION ALL
+            -- all group based permissions for the user, which is not the author
+            SELECT
+                document_roots.id AS document_root_id,
+                sg_to_user."B" AS user_id,
+                rgp.access AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                rgp.id AS root_group_permission_id,
+                sg.id AS group_id
+            FROM 
+                document_roots
+                INNER JOIN root_group_permissions rgp 
+                    ON (
+                        document_roots.id=rgp.document_root_id 
+                        AND rgp.access >= document_roots.shared_access
+                    )
+                INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN "_StudentGroupToUser" sg_to_user 
+                    ON (
+                        sg_to_user."A"=sg.id 
+                        AND sg_to_user."B"!=documents.author_id
+                    )
+            WHERE sg_to_user."B" IS NOT NULL
+    ) as doc_user_permissions;

--- a/prisma/migrations/20241119111720_fix_shared_access_in_view__all_document_user_permissions/migration.sql
+++ b/prisma/migrations/20241119111720_fix_shared_access_in_view__all_document_user_permissions/migration.sql
@@ -1,0 +1,190 @@
+
+CREATE OR REPLACE VIEW view__all_document_user_permissions AS
+    SELECT
+        document_root_id,
+        user_id,
+        access,
+        document_id,
+        root_user_permission_id,
+        root_group_permission_id,
+        group_id,
+        ROW_NUMBER() OVER (PARTITION BY document_root_id, user_id, document_id ORDER BY access DESC) AS access_rank
+    FROM (
+            -- get all documents where the user **is the author**
+            -- including all child documents
+            WITH RECURSIVE 
+                document_hierarchy AS (
+                    -- Anchor member: select the root document
+                    SELECT
+                        document_roots.id AS document_root_id,
+                        documents.id AS document_id,
+                        documents.author_id AS user_id,
+                        document_roots.access AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        document_roots
+                        INNER JOIN documents ON document_roots.id = documents.document_root_id
+                    WHERE documents.parent_id IS NULL  -- Assuming root documents have parent_id as NULL
+
+                    UNION ALL -- keeps duplicates in the result set
+
+                    -- Recursive member: select child documents with the parent's author as the user 
+                    SELECT
+                        document_hierarchy.document_root_id AS document_root_id,
+                        child_documents.id AS document_id,
+                        document_hierarchy.user_id AS user_id,
+                        document_hierarchy.access AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        document_hierarchy
+                        INNER JOIN documents AS child_documents ON document_hierarchy.document_id = child_documents.parent_id
+                ), 
+                -- get all documents where the user is **not the author**
+                -- but has been granted **shared access**
+                shared_doc_hierarchy AS (
+                    -- Anchor member: select the root document
+                    SELECT
+                        document_roots.id AS document_root_id,
+                        documents.id AS document_id,
+                        all_users.id AS user_id,
+                        CASE 
+                            WHEN document_roots.shared_access <= document_roots.access THEN document_roots.shared_access
+                            ELSE document_roots.access
+                        END AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        document_roots
+                        INNER JOIN documents ON document_roots.id = documents.document_root_id
+                        CROSS JOIN users all_users
+                    WHERE documents.parent_id IS NULL  -- Assuming root documents have parent_id as NULL
+                        AND documents.author_id != all_users.id
+                        AND document_roots.access != 'None_DocumentRoot'
+                        AND document_roots.shared_access != 'None_DocumentRoot'
+
+                    UNION ALL -- keeps duplicates in the result set
+
+                    -- Recursive member: select child documents with the parent's author as the user 
+                    SELECT
+                        shared_doc_hierarchy.document_root_id AS document_root_id,
+                        child_documents.id AS document_id,
+                        shared_doc_hierarchy.user_id AS user_id,
+                        shared_doc_hierarchy.access AS access,
+                        NULL::uuid AS root_user_permission_id,
+                        NULL::uuid AS root_group_permission_id,
+                        NULL::uuid AS group_id
+                    FROM 
+                        shared_doc_hierarchy
+                        INNER JOIN documents AS child_documents ON shared_doc_hierarchy.document_id = child_documents.parent_id
+                ) 
+            SELECT 
+                document_root_id,
+                user_id,
+                access,
+                document_id,
+                root_user_permission_id,
+                root_group_permission_id,
+                group_id
+            FROM document_hierarchy
+        UNION ALL
+            SELECT 
+                document_root_id,
+                user_id,
+                access,
+                document_id,
+                root_user_permission_id,
+                root_group_permission_id,
+                group_id
+            FROM shared_doc_hierarchy
+        UNION ALL
+            -- get all documents where the user has been granted shared access
+            -- or the access has been extended by user permissions
+            SELECT
+                document_roots.id AS document_root_id,
+                rup.user_id AS user_id,
+                CASE
+                    WHEN documents.author_id = rup.user_id THEN rup.access
+                    WHEN document_roots.shared_access = 'RO_DocumentRoot' THEN 'RO_User'
+                    WHEN document_roots.shared_access = 'RW_DocumentRoot' THEN 'RW_User'
+                    ELSE document_roots.shared_access
+                END AS access,
+                documents.id AS document_id,
+                rup.id AS root_user_permission_id,
+                NULL::uuid AS root_group_permission_id,
+                NULL::uuid AS group_id
+            FROM 
+                document_roots
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN root_user_permissions rup 
+                    ON (
+                        document_roots.id = rup.document_root_id 
+                        AND (
+                            documents.author_id = rup.user_id
+                            OR -- shared access
+                            (
+                                rup.access >= document_roots.shared_access
+                                AND document_roots.shared_access != 'None_DocumentRoot'
+                            )
+                        )
+                    )
+            WHERE rup.user_id IS NOT NULL
+        UNION ALL
+            -- all group-based permissions for the documents author
+            SELECT
+                document_roots.id AS document_root_id,
+                sg_to_user."B" AS user_id,
+                rgp.access AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                rgp.id AS root_group_permission_id,
+                sg.id AS group_id
+            FROM 
+                document_roots
+                INNER JOIN root_group_permissions rgp ON document_roots.id=rgp.document_root_id
+                INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN "_StudentGroupToUser" sg_to_user 
+                    ON (
+                        sg_to_user."A"=sg.id 
+                        AND (
+                            sg_to_user."B"=documents.author_id
+                            OR documents.author_id is null
+                        )
+                    )
+            WHERE sg_to_user."B" IS NOT NULL
+        UNION ALL
+            -- all group based permissions for the user, which is not the author
+            SELECT
+                document_roots.id AS document_root_id,
+                sg_to_user."B" AS user_id,
+                CASE
+                    WHEN document_roots.shared_access = 'RO_DocumentRoot' THEN 'RO_StudentGroup'
+                    WHEN document_roots.shared_access = 'RW_DocumentRoot' THEN 'RW_StudentGroup'
+                    ELSE document_roots.shared_access
+                END AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                rgp.id AS root_group_permission_id,
+                sg.id AS group_id
+            FROM 
+                document_roots
+                INNER JOIN root_group_permissions rgp 
+                    ON (
+                        document_roots.id=rgp.document_root_id 
+                        AND rgp.access >= document_roots.shared_access
+                        AND document_roots.shared_access != 'None_DocumentRoot'
+                    )
+                INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN "_StudentGroupToUser" sg_to_user 
+                    ON (
+                        sg_to_user."A"=sg.id 
+                        AND sg_to_user."B"!=documents.author_id
+                    )
+            WHERE sg_to_user."B" IS NOT NULL
+    ) as doc_user_permissions;

--- a/src/auth/guard.ts
+++ b/src/auth/guard.ts
@@ -100,9 +100,6 @@ const requestHasRequiredAttributes = (
     method: string,
     isAdmin: boolean
 ) => {
-    if (isAdmin) {
-        return true;
-    }
     const accessRules = Object.values(accessMatrix);
     const accessRule = accessRules
         .filter((accessRule) => accessRule.regex.test(path))
@@ -111,9 +108,11 @@ const requestHasRequiredAttributes = (
     if (!accessRule) {
         return false;
     }
-    return accessRule.access.some(
-        (rule) => !rule.adminOnly && rule.methods.includes(method as 'GET' | 'POST' | 'PUT' | 'DELETE')
+    const hasAccess = accessRule.access.some(
+        (rule) => (isAdmin || !rule.adminOnly) && rule.methods.includes(method as 'GET' | 'POST' | 'PUT' | 'DELETE')
     );
+    Logger.info(`${hasAccess ? '✅' : '❌'} Access Rule for ${isAdmin ? 'Admin' : 'User'}: [${method}:${path}] ${JSON.stringify(accessRule)}`);
+    return hasAccess;
 };
 
 export default routeGuard;

--- a/src/auth/guard.ts
+++ b/src/auth/guard.ts
@@ -109,9 +109,12 @@ const requestHasRequiredAttributes = (
         return false;
     }
     const hasAccess = accessRule.access.some(
-        (rule) => (isAdmin || !rule.adminOnly) && rule.methods.includes(method as 'GET' | 'POST' | 'PUT' | 'DELETE')
+        (rule) =>
+            (isAdmin || !rule.adminOnly) && rule.methods.includes(method as 'GET' | 'POST' | 'PUT' | 'DELETE')
     );
-    Logger.info(`${hasAccess ? '✅' : '❌'} Access Rule for ${isAdmin ? 'Admin' : 'User'}: [${method}:${path}] ${JSON.stringify(accessRule)}`);
+    Logger.info(
+        `${hasAccess ? '✅' : '❌'} Access Rule for ${isAdmin ? 'Admin' : 'User'}: [${method}:${path}] ${JSON.stringify(accessRule)}`
+    );
     return hasAccess;
 };
 

--- a/src/controllers/documentRoots.ts
+++ b/src/controllers/documentRoots.ts
@@ -1,10 +1,10 @@
 import { RequestHandler } from 'express';
 import DocumentRoot, { Config as CreateConfig, UpdateConfig } from '../models/DocumentRoot';
 import { ChangedRecord, IoEvent, RecordType } from '../routes/socketEventTypes';
-import { Access } from '@prisma/client';
 import { IoRoom } from '../routes/socketEvents';
 import { HTTP400Error, HTTP403Error } from '../utils/errors/Errors';
 import Document from '../models/Document';
+import { RO_RW_DocumentRootAccess } from '../helpers/accessPolicy';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
@@ -116,6 +116,27 @@ export const permissions: RequestHandler<{ id: string }> = async (req, res, next
     try {
         const permissions = await DocumentRoot.getPermissions(req.user!, req.params.id);
         res.json(permissions);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const destroy: RequestHandler<{ id: string }> = async (req, res, next) => {
+    try {
+        const model = await DocumentRoot.deleteModel(req.user!, req.params.id);
+
+        res.notifications = [
+            {
+                event: IoEvent.DELETED_RECORD,
+                message: { type: RecordType.DocumentRoot, id: model.id },
+                to: [
+                    ...model.rootGroupPermissions.map((p) => p.studentGroupId),
+                    ...model.rootUserPermissions.map((u) => u.userId),
+                    RO_RW_DocumentRootAccess.has(model.sharedAccess) ? IoRoom.ALL : IoRoom.ADMIN
+                ]
+            }
+        ];
+        res.json(model);
     } catch (error) {
         next(error);
     }

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -33,12 +33,14 @@ export const create: RequestHandler<any, any, DbDocument> = async (req, res, nex
          */
         const groupIds = permissions.group.filter((p) => !NoneAccess.has(p.access)).map((p) => p.groupId);
         const userIds = permissions.user.filter((p) => !NoneAccess.has(p.access)).map((p) => p.userId);
-        const sharedAccess = RO_RW_DocumentRootAccess.has(permissions.sharedAccess) ? [IoRoom.ALL] : [];
+        const sharedAccess = RO_RW_DocumentRootAccess.has(permissions.sharedAccess)
+            ? IoRoom.ALL
+            : IoRoom.ADMIN;
         res.notifications = [
             {
                 event: IoEvent.NEW_RECORD,
                 message: { type: RecordType.Document, record: model },
-                to: [...groupIds, ...userIds, ...sharedAccess, IoRoom.ADMIN, req.user!.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+                to: [...groupIds, ...userIds, sharedAccess, req.user!.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving,
             }
         ];
         res.status(200).json(model);

--- a/src/routes/authConfig.ts
+++ b/src/routes/authConfig.ts
@@ -135,7 +135,7 @@ const authConfig: Config = {
                     adminOnly: false
                 },
                 {
-                    methods: ['PUT'],
+                    methods: ['PUT', 'DELETE'],
                     adminOnly: true
                 }
             ]

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -32,7 +32,8 @@ import {
     update as updateDocumentRoot,
     permissions as allPermissions,
     findManyFor as findManyDocumentRootsFor,
-    allDocuments
+    allDocuments,
+    destroy as deleteDocumentRoot
 } from '../controllers/documentRoots';
 
 // initialize router
@@ -73,6 +74,7 @@ router.get('/documentRoots', findManyDocumentRoots);
 router.get('/documentRoots/:id', findDocumentRoot);
 router.post('/documentRoots/:id', createDocumentRoot);
 router.put('/documentRoots/:id', updateDocumentRoot);
+router.delete('/documentRoots/:id', deleteDocumentRoot);
 router.get('/documentRoots/:id/permissions', allPermissions);
 /**
  * TODO: Reactivate once the controller's permissions are updated.

--- a/src/routes/socketEventTypes.ts
+++ b/src/routes/socketEventTypes.ts
@@ -2,7 +2,7 @@ import { Prisma, User } from '@prisma/client';
 import { ApiDocument } from '../models/Document';
 import { ApiUserPermission } from '../models/RootUserPermission';
 import { ApiGroupPermission } from '../models/RootGroupPermission';
-import { ApiDocumentRootUpdate } from '../models/DocumentRoot';
+import { ApiDocumentRootWithoutDocuments } from '../models/DocumentRoot';
 
 export enum IoEvent {
     NEW_RECORD = 'NEW_RECORD',
@@ -25,7 +25,7 @@ type TypeRecordMap = {
     [RecordType.User]: User;
     [RecordType.UserPermission]: ApiUserPermission;
     [RecordType.GroupPermission]: ApiGroupPermission;
-    [RecordType.DocumentRoot]: ApiDocumentRootUpdate;
+    [RecordType.DocumentRoot]: ApiDocumentRootWithoutDocuments;
 };
 
 export interface NewRecord<T extends RecordType> {


### PR DESCRIPTION
# Fix: correctly provide documents when shared access was granted
The sharing-model was not fully implemented and in #23 a bug was introduced, where the user-access had precedence over the the shared permission in case the root access was None.

# Fix: ensure the route-guard is applied for admins too!
We somehow introduced that admin access is not checked by the route guard. (Maybe for debugging purpose?) I added a logger option for development to display route-guard infos

# Fix/Feature: notify users when new a new document root is created
When dynamic doc roots are created, users must be notified...
# Feature: api delete for root documents
When a root document is dynamically generated, an admin should be able to delete it again.
This is needed for https://github.com/GBSL-Informatik/teaching-dev/pull/47 