### PR TITLE
feature: default rw permission for admin group

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
+    "[scss]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[css]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "editor.formatOnSave": true,
     "files.exclude": {
         "**/*:Zone.Identifier": true
     }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ to format all typescript files.
 | `MSAL_CLIENT_ID`      | The client id for the web api from Azure.                                                                                                                                                       |                                                     |
 | `MSAL_TENANT_ID`      | The Tenant ID from your Azure instance                                                                                                                                                          |                                                     |
 | `APP_NAME`            | The name of the app. Used for the cookie name prefix `{APP_NAME}ApiKey`                                                                                                                         | `xyzTeaching`, default: `twa`                       |
-| `WITH_DEPLOY_PREVIEW` | When set to `true`, the app will allow requests from `https://deploy-preview-\d+--teaching-dev.netlify.app` and use `sameSite=none` instead of strict.                                                                                    |                                                     |
+| `WITH_DEPLOY_PREVIEW` | When set to `true`, the app will allow requests from `https://deploy-preview-\d+--teaching-dev.netlify.app` and use `sameSite=none` instead of strict.                                          |                                                     |
+| `ADMIN_USER_GROUP_ID` | The UUID of the group that should be used as the admin group. For this group a RW-Permission will be always added to a newly created document root when it's access is not RW                   | default: ""                                         |	
 
 
 \* When using MSAL Auth, use your `localAccountId` (check your local-storage when signed in, eg. at https://ofi.gbsl.website).<br/>

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -65,7 +65,7 @@ const prepareUserPermission = (permission: RootUserPermission): ApiUserPermissio
     };
 };
 
-const { ADMIN_USER_GROUP_ID } = process.env; 
+const { ADMIN_USER_GROUP_ID } = process.env;
 
 function DocumentRoot(db: PrismaClient['documentRoot']) {
     return Object.assign(db, {
@@ -185,8 +185,12 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
         },
         async createModel(id: string, config: Config = {}): Promise<ApiDocumentRootWithoutDocuments> {
             const groupPermissions = config.groupPermissions || [];
-            const access = asDocumentRootAccess(config.access); 
-            if (access !== Access.RW_DocumentRoot && ADMIN_USER_GROUP_ID && !groupPermissions.some(gp => gp.groupId === ADMIN_USER_GROUP_ID)) {
+            const access = asDocumentRootAccess(config.access);
+            if (
+                access !== Access.RW_DocumentRoot &&
+                ADMIN_USER_GROUP_ID &&
+                !groupPermissions.some((gp) => gp.groupId === ADMIN_USER_GROUP_ID)
+            ) {
                 groupPermissions.push({
                     groupId: ADMIN_USER_GROUP_ID,
                     access: Access.RW_DocumentRoot

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -65,6 +65,8 @@ const prepareUserPermission = (permission: RootUserPermission): ApiUserPermissio
     };
 };
 
+const { ADMIN_USER_GROUP_ID } = process.env; 
+
 function DocumentRoot(db: PrismaClient['documentRoot']) {
     return Object.assign(db, {
         async findModel(actor: User, id: string): Promise<ApiDocumentRoot | null> {
@@ -142,7 +144,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
             );
             /**
              * Possibly the user does not have documents in the requested document roots (and thus no docRoot is returned above).
-             * In this case, we have to load these document roots without the document roots.
+             * In this case, we have to load these documentRoots too.
              */
             if (missingDocumentRoots.length > 0 && !ignoreMissingRoots) {
                 const docRoots = await db.findMany({
@@ -182,17 +184,24 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
             return response;
         },
         async createModel(id: string, config: Config = {}): Promise<ApiDocumentRootWithoutDocuments> {
-            // TODO: assign a RW-Access for the admin group for each created doc-root!?
+            const groupPermissions = config.groupPermissions || [];
+            const access = asDocumentRootAccess(config.access); 
+            if (access !== Access.RW_DocumentRoot && ADMIN_USER_GROUP_ID && !groupPermissions.some(gp => gp.groupId === ADMIN_USER_GROUP_ID)) {
+                groupPermissions.push({
+                    groupId: ADMIN_USER_GROUP_ID,
+                    access: Access.RW_DocumentRoot
+                });
+            }
             const model = await db.create({
                 data: {
                     id: id,
-                    access: asDocumentRootAccess(config.access),
+                    access: access,
                     sharedAccess: config.sharedAccess || Access.None_DocumentRoot,
                     /* 0 is falsey in JS (since TS strictNullChecks is on, `grouPermissions?.length > 0` is not valid) */
-                    rootGroupPermissions: config.groupPermissions?.length
+                    rootGroupPermissions: groupPermissions.length
                         ? {
                               createMany: {
-                                  data: config.groupPermissions.map((p) => ({
+                                  data: groupPermissions.map((p) => ({
                                       access: asGroupAccess(p.access),
                                       studentGroupId: p.groupId
                                   }))


### PR DESCRIPTION
add RW permission for the admin group by default when the `access` is not set to RW.

This ensures that a main document can be always created by the admin...