### PR TITLE
feature: user roles and group-admins

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '>=22.11'
 
       - name: Install dependencies
         run: yarn install

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/*.svg
 dist/
 # Sentry Config File
 .sentryclirc
+
+src/generated/prisma

--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ In order to use `.env` files, the [dotenv-cli](https://www.npmjs.com/package/dot
 yarn global add dotenv-cli
 ```
 
+## Concepts
+
+### User Roles
+
+A user can have one of the following roles:
+- `ADMIN`: The user has full access to the system and can manage all resources. This includes
+  - CRUD\* operations on all resources
+  - Manage user roles and permissions
+  - Access to all system settings
+- `TEACHER`: The user can manage their own resources and has limited access to other users' resources. This includes
+  - CRUD\* operations on their own resources
+  - CRUD\* operations on StudentGroups (can create new groups, can add/remove users to/from groups they have admin access to)
+  - When a teacher creates a studentGroup and adds students to this group, the students are referenced as **managed** users.
+  - Can read docuements from managed users.
+  - Can CRUD user- and group-permissions for managed users and administrated groups.
+- `STUDENT`: The user has limited access to the system and can only manage their own resources.
+
+
+\* Documents can be updated always only by the user who created them. Except the document has excplicite shared permissions with other users/groups.
+
 ## Code Formatting
 
 For a consistent code style, the project uses [Prettier](https://prettier.io/). To format the code, run
@@ -175,23 +195,23 @@ this will generate
 the docs will be publically available under `/prisma/index.html`.
 
 ### Undo last migration (dev mode only!!!!)
-# connect to current db
+### connect to current db
 ```bash
 psql -d postgres -h localhost -U teaching_website -d teaching_website
 ```
 
-# delete last migration
+### delete last migration
 ```sql
 DELETE FROM _prisma_migrations WHERE started_at = (SELECT MAX(started_at)FROM _prisma_migrations);
 ```
 
-# undo your migration, e.g. drop a view or remove a column
+### undo your migration, e.g. drop a view or remove a column
 ```sql
 drop view view_name; -- drop view
 ALTER TABLE table_name DROP COLUMN column_name; -- drop column
 ```
 
-# disconnect
+### disconnect
 \q
 
 ## Deployment

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "prisma-erd-generator": "^2.0.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
+  },
+  "engines": {
+    "node": "^22.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "GBSL Informatik",
   "license": "CC-BY-SA",
   "scripts": {
-    "build": "yarn run prisma generate && tsc --build ./tsconfig.build.json && yarn sentry:sourcemaps",
+    "build": "yarn run prisma generate && tsc --build ./tsconfig.build.json && (yarn sentry:sourcemaps || true)",
     "start": "node -r dotenv/config ./dist/src/server.js",
     "dev": "dotenv -- nodemon src/server.ts",
     "dummy:run": "ts-node -r dotenv/config ./bin/dummy.ts",

--- a/prisma/migrations/20250418162735_add_admin_role_for_student_groups/migration.sql
+++ b/prisma/migrations/20250418162735_add_admin_role_for_student_groups/migration.sql
@@ -1,0 +1,197 @@
+BEGIN;
+DROP VIEW IF EXISTS view__document_user_permissions;
+DROP VIEW IF EXISTS view__all_document_user_permissions;
+DROP VIEW IF EXISTS view__users_documents;
+DROP INDEX "_StudentGroupToUser_B_index";
+ALTER TABLE "_StudentGroupToUser" RENAME TO "user_student_groups";
+ALTER TABLE "user_student_groups" RENAME CONSTRAINT "_StudentGroupToUser_AB_pkey" TO "user_student_groups_pkey";
+
+ALTER TABLE "user_student_groups" RENAME COLUMN "A" TO student_group_id;
+ALTER TABLE "user_student_groups" RENAME COLUMN "B" TO user_id;
+ALTER TABLE "user_student_groups" RENAME CONSTRAINT "_StudentGroupToUser_A_fkey" TO "user_student_groups_student_group_id_fkey";
+ALTER TABLE "user_student_groups" RENAME CONSTRAINT "_StudentGroupToUser_B_fkey" TO "user_student_groups_user_id_fkey";
+
+ALTER TABLE "user_student_groups" ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT false;
+CREATE INDEX "user_student_group_user_index" ON "user_student_groups"("user_id");
+COMMIT;
+
+-- assumption: all child documents of a document share the same document_root_id
+
+CREATE OR REPLACE VIEW view__all_document_user_permissions AS
+    SELECT
+        document_root_id,
+        user_id,
+        access,
+        document_id,
+        root_user_permission_id,
+        root_group_permission_id,
+        group_id,
+        ROW_NUMBER() OVER (PARTITION BY document_root_id, user_id, document_id ORDER BY access DESC) AS access_rank
+    FROM (
+            -- get all documents where the user **is the author**
+            SELECT
+                document_roots.id AS document_root_id,
+                documents.author_id AS user_id,
+                document_roots.access AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                NULL::uuid AS root_group_permission_id,
+                NULL::uuid AS group_id
+            FROM
+                document_roots
+                INNER JOIN documents ON document_roots.id = documents.document_root_id
+        UNION ALL
+            -- get all documents where the user **is not the author** but has shared access
+            SELECT
+                document_roots.id AS document_root_id,
+                all_users.id AS user_id,
+                CASE 
+                    WHEN document_roots.shared_access <= document_roots.access THEN document_roots.shared_access
+                    ELSE document_roots.access
+                END AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                NULL::uuid AS root_group_permission_id,
+                NULL::uuid AS group_id
+            FROM 
+                document_roots
+                INNER JOIN documents ON document_roots.id = documents.document_root_id
+                CROSS JOIN users all_users
+            WHERE documents.author_id != all_users.id
+                AND (
+                    document_roots.shared_access='RO_DocumentRoot' 
+                    OR
+                    document_roots.shared_access='RW_DocumentRoot'
+                )
+        UNION ALL
+            -- get all documents where the user has been granted shared access
+            -- or the access has been extended by user permissions
+            SELECT
+                document_roots.id AS document_root_id,
+                rup.user_id AS user_id,
+                rup.access AS access,
+                documents.id AS document_id,
+                rup.id AS root_user_permission_id,
+                NULL::uuid AS root_group_permission_id,
+                NULL::uuid AS group_id
+            FROM 
+                document_roots
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN root_user_permissions rup 
+                    ON (
+                        document_roots.id = rup.document_root_id 
+                        AND (
+                            documents.author_id = rup.user_id
+                            OR
+                            rup.access >= document_roots.shared_access
+                        )
+                    )
+            WHERE rup.user_id IS NOT NULL
+        UNION ALL
+            -- all group-based permissions for the documents author
+            SELECT
+                document_roots.id AS document_root_id,
+                user_to_sg.user_id AS user_id,
+                rgp.access AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                rgp.id AS root_group_permission_id,
+                sg.id AS group_id
+            FROM 
+                document_roots
+                INNER JOIN root_group_permissions rgp ON document_roots.id=rgp.document_root_id
+                INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN user_student_groups user_to_sg 
+                    ON (
+                        user_to_sg.student_group_id=sg.id 
+                        AND (
+                            user_to_sg.user_id=documents.author_id
+                            OR documents.author_id is null
+                        )
+                    )
+            WHERE user_to_sg.user_id IS NOT NULL
+        UNION ALL
+            -- all group based permissions for the user, which is not the author
+            SELECT
+                document_roots.id AS document_root_id,
+                user_to_sg.user_id AS user_id,
+                rgp.access AS access,
+                documents.id AS document_id,
+                NULL::uuid AS root_user_permission_id,
+                rgp.id AS root_group_permission_id,
+                sg.id AS group_id
+            FROM 
+                document_roots
+                INNER JOIN root_group_permissions rgp 
+                    ON (
+                        document_roots.id=rgp.document_root_id 
+                        AND rgp.access >= document_roots.shared_access
+                    )
+                INNER JOIN student_groups sg ON rgp.student_group_id=sg.id
+                LEFT JOIN documents ON document_roots.id=documents.document_root_id
+                LEFT JOIN user_student_groups user_to_sg 
+                    ON (
+                        user_to_sg.student_group_id=sg.id 
+                        AND user_to_sg.user_id!=documents.author_id
+                    )
+            WHERE user_to_sg.user_id IS NOT NULL
+    ) as doc_user_permissions;
+
+CREATE OR REPLACE VIEW view__users_documents AS
+    SELECT
+        view__document_user_permissions.user_id AS user_id,
+        document_roots.*,
+        COALESCE(
+            JSONB_AGG(
+                DISTINCT JSONB_BUILD_OBJECT(
+                    'id', view__document_user_permissions.root_group_permission_id,
+                    'access', view__document_user_permissions.access,
+                    'groupId', view__document_user_permissions.group_id
+                )
+            ) FILTER (WHERE view__document_user_permissions.root_group_permission_id IS NOT NULL),
+            '[]'::jsonb
+        ) AS "groupPermissions",
+        COALESCE(
+            JSONB_AGG(
+                DISTINCT JSONB_BUILD_OBJECT(
+                    'id', view__document_user_permissions.root_user_permission_id,
+                    'access', view__document_user_permissions.access,
+                    'userId', view__document_user_permissions.user_id
+                )
+            ) FILTER (WHERE view__document_user_permissions.root_user_permission_id IS NOT NULL),
+            '[]'::jsonb
+        ) AS "userPermissions",
+        COALESCE(
+            JSONB_AGG(
+                JSONB_BUILD_OBJECT(
+                    'id', d.id,
+                    'authorId', d.author_id,
+                    'type', d.type,
+                    'data', CASE WHEN (view__document_user_permissions.access='None_DocumentRoot' OR view__document_user_permissions.access='None_StudentGroup' OR view__document_user_permissions.access='None_User') THEN NULL ELSE d.data END,
+                    'parentId', d.parent_id,
+                    'documentRootId', d.document_root_id,
+                    'createdAt', d.created_at,
+                    'updatedAt', d.updated_at
+                )
+            ) FILTER (WHERE d.id IS NOT NULL),
+            '[]'::jsonb
+        ) AS documents
+    FROM
+        document_roots
+            LEFT JOIN view__document_user_permissions ON document_roots.id=view__document_user_permissions.document_root_id
+            LEFT JOIN documents d ON document_roots.id=d.document_root_id AND view__document_user_permissions.document_id=d.id
+    WHERE view__document_user_permissions.user_id IS NOT NULL
+    GROUP BY document_roots.id, view__document_user_permissions.user_id;
+
+CREATE OR REPLACE VIEW view__document_user_permissions AS
+    SELECT
+        document_root_id,
+        user_id,
+        access,
+        document_id,
+        root_user_permission_id,
+        root_group_permission_id,
+        group_id
+    FROM view__all_document_user_permissions
+    WHERE access_rank = 1;

--- a/prisma/migrations/20250420122358_introduce_user_roles/migration.sql
+++ b/prisma/migrations/20250420122358_introduce_user_roles/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('STUDENT', 'TEACHER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "role" "Role" NOT NULL DEFAULT 'STUDENT';
+UPDATE "users" SET "role" = 'ADMIN' WHERE "is_admin" = true;
+ALTER TABLE "users" DROP COLUMN "is_admin";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,16 +1,17 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["postgresqlExtensions", "views", "relationJoins"]
+  output          = "../docs/prisma"
 }
 
 generator docs {
   provider = "node node_modules/prisma-docs-generator"
-  output   = "../docs/prisma"
+  output   = "../src/generated/prisma"
 }
 
-generator dbml {
-  provider = "prisma-dbml-generator"
-}
+// generator dbml {
+//   provider = "prisma-dbml-generator"
+// }
 
 datasource db {
   provider   = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,11 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["postgresqlExtensions", "views", "relationJoins"]
-  output          = "../docs/prisma"
 }
 
 generator docs {
   provider = "node node_modules/prisma-docs-generator"
-  output   = "../src/generated/prisma"
+  output   = "../docs/prisma"
 }
 
 // generator dbml {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,10 +8,6 @@ generator docs {
   output   = "../docs/prisma"
 }
 
-// generator dbml {
-//   provider = "prisma-dbml-generator"
-// }
-
 datasource db {
   provider   = "postgresql"
   url        = env("DATABASE_URL")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,10 +28,10 @@ model User {
   updatedAt                       DateTime                          @default(now()) @updatedAt @map("updated_at")
   documents                       Document[]                        @relation("documents")
   rootUserPermissions             RootUserPermission[]              @relation("root_user_to_user_permission")
-  studentGroups                   StudentGroup[]                    @relation("StudentGroupToUser")
   view_DocumentUserPermissions    view_DocumentUserPermissions[]
   view_AllDocumentUserPermissions view_AllDocumentUserPermissions[]
   cmsSettings                     CmsSettings?
+  studentGroups                   UserStudentGroup[]                @relation("user_student_groups")
 
   @@map("users")
 }
@@ -55,17 +55,30 @@ model CmsSettings {
   @@map("cms_settings")
 }
 
+model UserStudentGroup {
+  userId         String       @map("user_id") @db.Uuid
+  studentGroupId String       @map("student_group_id") @db.Uuid
+  isAdmin        Boolean      @default(false) @map("is_admin")
+  user           User         @relation("user_student_groups", fields: [userId], references: [id], onDelete: Cascade)
+  studentGroup   StudentGroup @relation("user_student_groups", fields: [studentGroupId], references: [id], onDelete: Cascade)
+
+  @@id([userId, studentGroupId], name: "id", map: "user_student_groups_pkey")
+  @@index([userId], map: "user_student_group_user_index")
+  @@map("user_student_groups")
+}
+
 model StudentGroup {
-  id                              String                            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name                            String                            @default("")
-  description                     String                            @default("")
-  parentId                        String?                           @map("parent_id") @db.Uuid
-  createdAt                       DateTime                          @default(now()) @map("created_at")
-  updatedAt                       DateTime                          @default(now()) @updatedAt @map("updated_at")
-  rootGroupPermissions            RootGroupPermission[]             @relation("root_group_to_student_group_permission")
-  parent                          StudentGroup?                     @relation("parent_student_group", fields: [parentId], references: [id], onDelete: Cascade)
-  children                        StudentGroup[]                    @relation("parent_student_group")
-  users                           User[]                            @relation("StudentGroupToUser")
+  id                   String                @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name                 String                @default("")
+  description          String                @default("")
+  parentId             String?               @map("parent_id") @db.Uuid
+  createdAt            DateTime              @default(now()) @map("created_at")
+  updatedAt            DateTime              @default(now()) @updatedAt @map("updated_at")
+  rootGroupPermissions RootGroupPermission[] @relation("root_group_to_student_group_permission")
+  parent               StudentGroup?         @relation("parent_student_group", fields: [parentId], references: [id], onDelete: Cascade)
+  children             StudentGroup[]        @relation("parent_student_group")
+  users                UserStudentGroup[]    @relation("user_student_groups")
+
   view_DocumentUserPermissions    view_DocumentUserPermissions[]
   view_AllDocumentUserPermissions view_AllDocumentUserPermissions[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model User {
   email                           String                            @unique
   firstName                       String                            @map("first_name")
   lastName                        String                            @map("last_name")
-  isAdmin                         Boolean                           @default(false) @map("is_admin")
+  role                            Role                              @default(STUDENT) @map("role")
   createdAt                       DateTime                          @default(now()) @map("created_at")
   updatedAt                       DateTime                          @default(now()) @updatedAt @map("updated_at")
   documents                       Document[]                        @relation("documents")
@@ -230,4 +230,10 @@ enum Access {
   RO_User
   RW_User
   None_User
+}
+
+enum Role {
+  STUDENT
+  TEACHER
+  ADMIN
 }

--- a/prisma/seed-files/users.ts
+++ b/prisma/seed-files/users.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, Role } from '@prisma/client';
 
 export const FOO_BAR_ID = '96651c13-3af6-4cc0-b242-ea38d438dc41';
 export const TEST_USER_ID = '4b6d8b5d-3b6c-4c8b-8d3c-6f2c3f6e2b4b';
@@ -28,7 +28,7 @@ if (USER_EMAIL && USER_ID) {
         id: USER_ID,
         firstName: name.split('.')[0],
         lastName: name.split('.')[1] || name,
-        isAdmin: true
+        role: Role.ADMIN
     });
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -55,7 +55,10 @@ async function main() {
         where: { id: ALL_USERS_GROUP_ID },
         data: {
             users: {
-                connect: allUsersGroupMembers
+                connectOrCreate: allUsersGroupMembers.map((user) => ({
+                    where: { id: { studentGroupId: ALL_USERS_GROUP_ID, userId: user.id } },
+                    create: { userId: user.id }
+                }))
             }
         }
     });
@@ -63,7 +66,16 @@ async function main() {
         where: { id: CLASS_GROUP_ID },
         data: {
             users: {
-                connect: [{ id: FOO_BAR_ID }, { id: TEST_USER_ID }]
+                connectOrCreate: [
+                    {
+                        where: { id: { studentGroupId: CLASS_GROUP_ID, userId: FOO_BAR_ID } },
+                        create: { userId: FOO_BAR_ID }
+                    },
+                    {
+                        where: { id: { studentGroupId: CLASS_GROUP_ID, userId: FOO_BAR_ID } },
+                        create: { userId: TEST_USER_ID }
+                    }
+                ]
             }
         }
     });
@@ -71,7 +83,12 @@ async function main() {
         where: { id: PROJECT_GROUP_ID },
         data: {
             users: {
-                connect: [{ id: FOO_BAR_ID }]
+                connectOrCreate: [
+                    {
+                        where: { id: { studentGroupId: PROJECT_GROUP_ID, userId: FOO_BAR_ID } },
+                        create: { userId: FOO_BAR_ID }
+                    }
+                ]
             }
         }
     });

--- a/src/controllers/documentRoots.ts
+++ b/src/controllers/documentRoots.ts
@@ -5,6 +5,7 @@ import { IoRoom } from '../routes/socketEvents';
 import { HTTP400Error, HTTP403Error } from '../utils/errors/Errors';
 import Document from '../models/Document';
 import { NoneAccess, RO_RW_DocumentRootAccess } from '../helpers/accessPolicy';
+import { hasElevatedAccess } from '../models/User';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
@@ -38,7 +39,7 @@ export const findManyFor: RequestHandler<
         if (!req.params.id) {
             throw new HTTP400Error('Missing user id');
         }
-        const canLoad = req.user!.id === req.params.id || req.user?.isAdmin;
+        const canLoad = req.user!.id === req.params.id || hasElevatedAccess(req.user?.role);
         if (!canLoad) {
             throw new HTTP403Error('Not Authorized');
         }
@@ -59,7 +60,7 @@ export const findManyFor: RequestHandler<
 
 export const allDocuments: RequestHandler<any, any, any, { rids: string[] }> = async (req, res, next) => {
     try {
-        if (!req.user!.isAdmin) {
+        if (!hasElevatedAccess(req.user!.role)) {
             throw new HTTP403Error('Not Authorized');
         }
         const ids = Array.isArray(req.query.rids) ? req.query.rids : [req.query.rids];

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -35,7 +35,8 @@ export const create: RequestHandler<
                     id: onBehalfUserId,
                     studentGroups: {
                         some: {
-                            userId: req.user!.id
+                            userId: req.user!.id,
+                            isAdmin: true
                         }
                     }
                 }

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -1,4 +1,4 @@
-import { Document as DbDocument, Prisma, Role } from '@prisma/client';
+import { Document as DbDocument, Prisma } from '@prisma/client';
 import { RequestHandler } from 'express';
 import Document from '../models/Document';
 import { JsonObject } from '@prisma/client/runtime/library';
@@ -7,7 +7,6 @@ import { IoRoom } from '../routes/socketEvents';
 import { NoneAccess, RO_RW_DocumentRootAccess, RWAccess } from '../helpers/accessPolicy';
 import prisma from '../prisma';
 import { HTTP403Error, HTTP404Error } from '../utils/errors/Errors';
-import { hasElevatedAccess, whereStudentGroupAccess } from '../models/User';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -7,6 +7,7 @@ import { IoRoom } from '../routes/socketEvents';
 import { NoneAccess, RO_RW_DocumentRootAccess, RWAccess } from '../helpers/accessPolicy';
 import prisma from '../prisma';
 import { HTTP403Error, HTTP404Error } from '../utils/errors/Errors';
+import { hasElevatedAccess } from '../models/User';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
@@ -26,7 +27,8 @@ export const create: RequestHandler<
     try {
         const { type, documentRootId, data, parentId } = req.body;
         const { onBehalfOf, uniqueMain } = req.query;
-        const onBehalfUser = onBehalfOf === 'true' && req.user!.isAdmin ? req.body.authorId : undefined;
+        const elevatedAccess = hasElevatedAccess(req.user?.role);
+        const onBehalfUser = onBehalfOf === 'true' && elevatedAccess ? req.body.authorId : undefined;
         const { model, permissions } = await Document.createModel(
             req.user!,
             type,

--- a/src/controllers/rootGroupPermissions.ts
+++ b/src/controllers/rootGroupPermissions.ts
@@ -16,7 +16,7 @@ export const create: RequestHandler<
             throw new HTTP400Error('Missing documentRootId, groupId or access');
         }
 
-        const model = await RootGroupPermission.createModel(documentRootId, groupId, access);
+        const model = await RootGroupPermission.createModel(req.user!, documentRootId, groupId, access);
 
         res.notifications = [
             {
@@ -33,7 +33,7 @@ export const create: RequestHandler<
 
 export const update: RequestHandler<{ id: string }, any, { access: Access }> = async (req, res, next) => {
     try {
-        const model = await RootGroupPermission.updateModel(req.params.id, req.body.access);
+        const model = await RootGroupPermission.updateModel(req.user!, req.params.id, req.body.access);
 
         res.notifications = [
             {
@@ -50,7 +50,7 @@ export const update: RequestHandler<{ id: string }, any, { access: Access }> = a
 
 export const destroy: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
-        const model = await RootGroupPermission.deleteModel(req.params.id);
+        const model = await RootGroupPermission.deleteModel(req.user!, req.params.id);
 
         res.notifications = [
             {

--- a/src/controllers/rootUserPermissions.ts
+++ b/src/controllers/rootUserPermissions.ts
@@ -17,7 +17,7 @@ export const create: RequestHandler<
             throw new HTTP400Error('Missing documentRootId, userId or access');
         }
 
-        const model = await RootUserPermission.createModel(documentRootId, userId, access);
+        const model = await RootUserPermission.createModel(req.user!, documentRootId, userId, access);
 
         res.notifications = [
             {
@@ -37,7 +37,7 @@ export const update: RequestHandler<{ id: string }, any, { access: Access }> = a
         if (!req.params.id) {
             throw new HTTP400Error('Missing id');
         }
-        const model = await RootUserPermission.updateModel(req.params.id, req.body.access);
+        const model = await RootUserPermission.updateModel(req.user!, req.params.id, req.body.access);
 
         res.notifications = [
             {
@@ -57,7 +57,7 @@ export const destroy: RequestHandler<{ id: string }> = async (req, res, next) =>
         if (!req.params.id) {
             throw new HTTP400Error('Missing id');
         }
-        const model = await RootUserPermission.deleteModel(req.params.id);
+        const model = await RootUserPermission.deleteModel(req.user!, req.params.id);
 
         res.notifications = [
             {

--- a/src/controllers/studentGroups.ts
+++ b/src/controllers/studentGroups.ts
@@ -5,7 +5,7 @@ import StudentGroup from '../models/StudentGroup';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
-        const group = await StudentGroup.findModel(req.params.id);
+        const group = await StudentGroup.findModel(req.user!, req.params.id);
         res.json(group);
     } catch (error) {
         next(error);
@@ -14,9 +14,8 @@ export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
 
 export const create: RequestHandler<any, any, DbStudentGroup> = async (req, res, next) => {
     try {
-        Logger.info(req.body);
         const { name, description, parentId } = req.body;
-        const model = await StudentGroup.createModel(name, description, parentId);
+        const model = await StudentGroup.createModel(req.user!, name, description, parentId);
         res.status(200).json(model);
     } catch (error) {
         next(error);

--- a/src/controllers/studentGroups.ts
+++ b/src/controllers/studentGroups.ts
@@ -29,6 +29,9 @@ export const update: RequestHandler<{ id: string }, any, { data: DbStudentGroup 
 ) => {
     try {
         const model = await StudentGroup.updateModel(req.user!, req.params.id, req.body.data);
+        if (!model) {
+            return res.status(404).json({ message: 'Student group not found' });
+        }
 
         res.notifications = [
             {

--- a/src/controllers/studentGroups.ts
+++ b/src/controllers/studentGroups.ts
@@ -36,6 +36,24 @@ export const update: RequestHandler<{ id: string }, any, { data: DbStudentGroup 
     }
 };
 
+export const setAdminRole: RequestHandler<{ id: string; userId: string }, any, { isAdmin: boolean }> = async (
+    req,
+    res,
+    next
+) => {
+    try {
+        const model = await StudentGroup.setAdminRole(
+            req.user!,
+            req.params.id,
+            req.params.userId,
+            req.body.isAdmin
+        );
+        res.status(200).json(model);
+    } catch (error) {
+        next(error);
+    }
+};
+
 export const addUser: RequestHandler<{ id: string; userId: string }, any, any> = async (req, res, next) => {
     try {
         const model = await StudentGroup.addUser(req.user!, req.params.id, req.params.userId);

--- a/src/controllers/studentGroups.ts
+++ b/src/controllers/studentGroups.ts
@@ -1,6 +1,5 @@
 import { StudentGroup as DbStudentGroup } from '@prisma/client';
 import { RequestHandler } from 'express';
-import Logger from '../utils/logger';
 import StudentGroup from '../models/StudentGroup';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {

--- a/src/controllers/studentGroups.ts
+++ b/src/controllers/studentGroups.ts
@@ -1,6 +1,7 @@
 import { StudentGroup as DbStudentGroup } from '@prisma/client';
 import { RequestHandler } from 'express';
 import StudentGroup from '../models/StudentGroup';
+import { IoEvent, RecordType } from '../routes/socketEventTypes';
 
 export const find: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
@@ -28,6 +29,17 @@ export const update: RequestHandler<{ id: string }, any, { data: DbStudentGroup 
 ) => {
     try {
         const model = await StudentGroup.updateModel(req.user!, req.params.id, req.body.data);
+
+        res.notifications = [
+            {
+                event: IoEvent.CHANGED_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    record: model
+                },
+                to: [model.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            }
+        ];
         res.status(200).json(model);
     } catch (error) {
         next(error);
@@ -46,6 +58,16 @@ export const setAdminRole: RequestHandler<{ id: string; userId: string }, any, {
             req.params.userId,
             req.body.isAdmin
         );
+        res.notifications = [
+            {
+                event: IoEvent.CHANGED_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    record: model
+                },
+                to: [model.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            }
+        ];
         res.status(200).json(model);
     } catch (error) {
         next(error);
@@ -55,6 +77,24 @@ export const setAdminRole: RequestHandler<{ id: string; userId: string }, any, {
 export const addUser: RequestHandler<{ id: string; userId: string }, any, any> = async (req, res, next) => {
     try {
         const model = await StudentGroup.addUser(req.user!, req.params.id, req.params.userId);
+        res.notifications = [
+            {
+                event: IoEvent.CHANGED_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    record: model
+                },
+                to: [model.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            },
+            {
+                event: IoEvent.NEW_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    record: model
+                },
+                to: [req.params.userId] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            }
+        ];
         res.status(200).json(model);
     } catch (error) {
         next(error);
@@ -68,6 +108,24 @@ export const removeUser: RequestHandler<{ id: string; userId: string }, any, any
 ) => {
     try {
         const model = await StudentGroup.removeUser(req.user!, req.params.id, req.params.userId);
+        res.notifications = [
+            {
+                event: IoEvent.CHANGED_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    record: model
+                },
+                to: [req.params.userId, model.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            },
+            {
+                event: IoEvent.DELETED_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    id: model.id
+                },
+                to: [req.params.userId] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            }
+        ];
         res.status(200).json(model);
     } catch (error) {
         next(error);
@@ -86,6 +144,16 @@ export const all: RequestHandler = async (req, res, next) => {
 export const destroy: RequestHandler<{ id: string }> = async (req, res, next) => {
     try {
         const group = await StudentGroup.deleteModel(req.user!, req.params.id);
+        res.notifications = [
+            {
+                event: IoEvent.DELETED_RECORD,
+                message: {
+                    type: RecordType.StudentGroup,
+                    id: group.id
+                },
+                to: [group.id] // overlappings are handled by socket.io: https://socket.io/docs/v3/rooms/#joining-and-leaving
+            }
+        ];
         res.json(group);
     } catch (error) {
         next(error);

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -1,4 +1,4 @@
-import { User as DbUser } from '@prisma/client';
+import { User as DbUser, Role } from '@prisma/client';
 import { RequestHandler } from 'express';
 import User from '../models/User';
 import Logger from '../utils/logger';
@@ -34,13 +34,13 @@ export const all: RequestHandler = async (req, res, next) => {
     }
 };
 
-export const setIsAdmin: RequestHandler<{ id: string }, any, { data: { isAdmin: boolean } }> = async (
+export const setRole: RequestHandler<{ id: string }, any, { data: { role: Role } }> = async (
     req,
     res,
     next
 ) => {
     try {
-        const user = await User.setIsAdmin(req.user!, req.params.id, req.body.data.isAdmin);
+        const user = await User.setRole(req.user!, req.params.id, req.body.data.role);
         res.json(user);
     } catch (error) {
         next(error);

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -33,16 +33,3 @@ export const all: RequestHandler = async (req, res, next) => {
         next(error);
     }
 };
-
-export const setRole: RequestHandler<{ id: string }, any, { data: { role: Role } }> = async (
-    req,
-    res,
-    next
-) => {
-    try {
-        const user = await User.setRole(req.user!, req.params.id, req.body.data.role);
-        res.json(user);
-    } catch (error) {
-        next(error);
-    }
-};

--- a/src/models/Document.ts
+++ b/src/models/Document.ts
@@ -245,7 +245,8 @@ function Document(db: PrismaClient['document']) {
                                   author: {
                                       studentGroups: {
                                           some: {
-                                              userId: actor.id
+                                              userId: actor.id,
+                                              isAdmin: true
                                           }
                                       }
                                   }
@@ -361,7 +362,8 @@ function Document(db: PrismaClient['document']) {
                     author: {
                         studentGroups: {
                             some: {
-                                userId: actor.id
+                                userId: actor.id,
+                                isAdmin: true
                             }
                         }
                     }

--- a/src/models/Document.ts
+++ b/src/models/Document.ts
@@ -81,7 +81,7 @@ function Document(db: PrismaClient['document']) {
                                         studentGroup: {
                                             users: {
                                                 some: {
-                                                    id: actor.id
+                                                    userId: actor.id
                                                 }
                                             }
                                         }
@@ -179,7 +179,7 @@ function Document(db: PrismaClient['document']) {
                                         studentGroup: {
                                             users: {
                                                 some: {
-                                                    id: authorId
+                                                    userId: authorId
                                                 }
                                             }
                                         }

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -13,6 +13,7 @@ import { ApiUserPermission } from './RootUserPermission';
 import { ApiGroupPermission } from './RootGroupPermission';
 import { HTTP403Error, HTTP404Error } from '../utils/errors/Errors';
 import { asDocumentRootAccess, asGroupAccess, asUserAccess } from '../helpers/accessPolicy';
+import { hasElevatedAccess } from './User';
 
 export type ApiDocumentRoot = DbDocumentRoot & {
     documents: ApiDocument[];
@@ -261,7 +262,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
             };
         },
         async getPermissions(actor: User, id: string): Promise<Permissions> {
-            if (!actor.isAdmin) {
+            if (!hasElevatedAccess(actor.role)) {
                 throw new HTTP403Error('Not authorized');
             }
             const userPermissions = await prisma.rootUserPermission.findMany({
@@ -285,7 +286,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
             if (!record) {
                 throw new HTTP404Error('DocumentRoot not found');
             }
-            if (!actor.isAdmin) {
+            if (!hasElevatedAccess(actor.role)) {
                 throw new HTTP403Error('Not authorized');
             }
 

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -98,7 +98,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
                                 studentGroup: {
                                     users: {
                                         some: {
-                                            id: actor.id
+                                            userId: actor.id
                                         }
                                     }
                                 }
@@ -164,7 +164,7 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
                                 studentGroup: {
                                     users: {
                                         some: {
-                                            id: actorId
+                                            userId: actorId
                                         }
                                     }
                                 }

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -275,7 +275,8 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
                               user: {
                                   studentGroups: {
                                       some: {
-                                          userId: actor.id
+                                          userId: actor.id,
+                                          isAdmin: true
                                       }
                                   }
                               }
@@ -291,7 +292,8 @@ function DocumentRoot(db: PrismaClient['documentRoot']) {
                               user: {
                                   studentGroups: {
                                       some: {
-                                          userId: actor.id
+                                          userId: actor.id,
+                                          isAdmin: true
                                       }
                                   }
                               }

--- a/src/models/RootGroupPermission.ts
+++ b/src/models/RootGroupPermission.ts
@@ -1,6 +1,7 @@
-import { Access, PrismaClient, RootGroupPermission as DbGroupPermission } from '@prisma/client';
+import { Access, PrismaClient, RootGroupPermission as DbGroupPermission, User, Role } from '@prisma/client';
 import prisma from '../prisma';
 import { asGroupAccess } from '../helpers/accessPolicy';
+import { hasElevatedAccess } from './User';
 
 // TODO: Consider checking existence of documentRoot / studentGroup to provide better error messages / exceptions.
 
@@ -17,14 +18,6 @@ export type CompleteApiGroupPermission = {
     access: Access;
 };
 
-function asApiRecord(dbResult: DbGroupPermission): ApiGroupPermission {
-    return {
-        id: dbResult.id,
-        groupId: dbResult.studentGroupId,
-        access: dbResult.access
-    };
-}
-
 function asCompleteApiRecord(dbResult: DbGroupPermission): CompleteApiGroupPermission {
     return {
         id: dbResult.id,
@@ -33,14 +26,38 @@ function asCompleteApiRecord(dbResult: DbGroupPermission): CompleteApiGroupPermi
         access: dbResult.access
     };
 }
+const ensureAccessOrThrow = async (actor: User, groupId: string) => {
+    const group = await prisma.studentGroup.findUnique({
+        where: {
+            id: groupId,
+            users: {
+                some: {
+                    userId: actor.id,
+                    isAdmin: true
+                }
+            }
+        }
+    });
+    if (!group) {
+        throw new Error('Not authorized');
+    }
+};
 
 function RootGroupPermission(db: PrismaClient['rootGroupPermission']) {
     return Object.assign(db, {
         async createModel(
+            actor: User,
             documentRootId: string,
             studentGroupId: string,
             access: Access
         ): Promise<CompleteApiGroupPermission> {
+            if (!hasElevatedAccess(actor.role)) {
+                throw new Error('Not authorized');
+            }
+            if (actor.role === Role.TEACHER) {
+                ensureAccessOrThrow(actor, studentGroupId);
+            }
+
             const result = await db.create({
                 data: {
                     documentRootId: documentRootId,
@@ -51,7 +68,18 @@ function RootGroupPermission(db: PrismaClient['rootGroupPermission']) {
             return asCompleteApiRecord(result);
         },
 
-        async updateModel(id: string, access: Access): Promise<CompleteApiGroupPermission> {
+        async updateModel(actor: User, id: string, access: Access): Promise<CompleteApiGroupPermission> {
+            if (!hasElevatedAccess(actor.role)) {
+                throw new Error('Not authorized');
+            }
+            const record = await db.findUnique({ where: { id: id } });
+            if (!record) {
+                throw new Error('User permission not found');
+            }
+            if (actor.role === Role.TEACHER) {
+                ensureAccessOrThrow(actor, record.studentGroupId);
+            }
+
             const result = await db.update({
                 where: {
                     id: id
@@ -63,7 +91,18 @@ function RootGroupPermission(db: PrismaClient['rootGroupPermission']) {
             return asCompleteApiRecord(result);
         },
 
-        async deleteModel(id: string): Promise<CompleteApiGroupPermission> {
+        async deleteModel(actor: User, id: string): Promise<CompleteApiGroupPermission> {
+            if (!hasElevatedAccess(actor.role)) {
+                throw new Error('Not authorized');
+            }
+            const record = await db.findUnique({ where: { id: id } });
+            if (!record) {
+                throw new Error('User permission not found');
+            }
+            if (actor.role === Role.TEACHER) {
+                ensureAccessOrThrow(actor, record.studentGroupId);
+            }
+
             const result = await db.delete({
                 where: {
                     id: id

--- a/src/models/RootUserPermission.ts
+++ b/src/models/RootUserPermission.ts
@@ -1,7 +1,8 @@
-import { Access, PrismaClient } from '@prisma/client';
+import { Access, PrismaClient, Role } from '@prisma/client';
 import prisma from '../prisma';
-import { RootUserPermission as DbRootUserPermission } from '.prisma/client';
+import { RootUserPermission as DbRootUserPermission, User } from '@prisma/client';
 import { asUserAccess } from '../helpers/accessPolicy';
+import { hasElevatedAccess, whereStudentGroupAccess } from './User';
 
 // TODO: Consider checking existence of documentRoot / user to provide better error messages / exceptions.
 
@@ -11,21 +12,32 @@ export type ApiUserPermission = {
     access: Access;
 };
 
-function asApiRecord(dbResult: DbRootUserPermission): ApiUserPermission {
-    return {
-        id: dbResult.id,
-        userId: dbResult.userId,
-        access: dbResult.access
-    };
-}
+const ensureAccessOrThrow = async (actor: User, userId: string) => {
+    const user = await prisma.user.findUnique({
+        where: {
+            id: userId,
+            ...whereStudentGroupAccess(actor.id, true)
+        }
+    });
+    if (!user) {
+        throw new Error('Not authorized');
+    }
+};
 
 function RootUserPermission(db: PrismaClient['rootUserPermission']) {
     return Object.assign(db, {
         async createModel(
+            actor: User,
             documentRootId: string,
             userId: string,
             access: Access
         ): Promise<DbRootUserPermission> {
+            if (!hasElevatedAccess(actor.role)) {
+                throw new Error('Not authorized');
+            }
+            if (actor.role === Role.TEACHER) {
+                ensureAccessOrThrow(actor, userId);
+            }
             const result = await db.create({
                 data: {
                     documentRootId: documentRootId,
@@ -36,7 +48,17 @@ function RootUserPermission(db: PrismaClient['rootUserPermission']) {
             return result;
         },
 
-        async updateModel(id: string, access: Access): Promise<DbRootUserPermission> {
+        async updateModel(actor: User, id: string, access: Access): Promise<DbRootUserPermission> {
+            if (!hasElevatedAccess(actor.role)) {
+                throw new Error('Not authorized');
+            }
+            const record = await db.findUnique({ where: { id: id } });
+            if (!record) {
+                throw new Error('User permission not found');
+            }
+            if (actor.role === Role.TEACHER) {
+                ensureAccessOrThrow(actor, record.userId);
+            }
             const result = await db.update({
                 where: {
                     id: id
@@ -48,7 +70,17 @@ function RootUserPermission(db: PrismaClient['rootUserPermission']) {
             return result;
         },
 
-        async deleteModel(id: string): Promise<ApiUserPermission> {
+        async deleteModel(actor: User, id: string): Promise<ApiUserPermission> {
+            if (!hasElevatedAccess(actor.role)) {
+                throw new Error('Not authorized');
+            }
+            const record = await db.findUnique({ where: { id: id } });
+            if (!record) {
+                throw new Error('User permission not found');
+            }
+            if (actor.role === Role.TEACHER) {
+                ensureAccessOrThrow(actor, record.userId);
+            }
             const result = await db.delete({
                 where: {
                     id: id

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -13,14 +13,14 @@ type ApiStudentGroup = DbStudentGroup & {
 };
 
 const asApiRecord = (
-    record: (DbStudentGroup & { users: { id: string }[] }) | null
+    record: (DbStudentGroup & { users: { userId: string }[] }) | null
 ): ApiStudentGroup | null => {
     if (!record) {
         return null;
     }
     const group = {
         ...record,
-        userIds: record.users.map((user) => user.id)
+        userIds: record.users.map((user) => user.userId)
     };
     delete (group as any).users;
     return group;
@@ -36,7 +36,7 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                 include: {
                     users: {
                         select: {
-                            id: true
+                            userId: true
                         }
                     }
                 }
@@ -78,7 +78,10 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                 data: {
                     users: {
                         connect: {
-                            id: userId
+                            id: {
+                                userId: userId,
+                                studentGroupId: record.id
+                            }
                         }
                     }
                 }
@@ -101,7 +104,10 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                 data: {
                     users: {
                         disconnect: {
-                            id: userId
+                            id: {
+                                userId: userId,
+                                studentGroupId: record.id
+                            }
                         }
                     }
                 }
@@ -122,14 +128,14 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                     : {
                           users: {
                               some: {
-                                  id: actor.id
+                                  userId: actor.id
                               }
                           }
                       },
                 include: {
                     users: {
                         select: {
-                            id: true
+                            userId: true
                         }
                     }
                 }

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -55,19 +55,16 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
         async findModel(actor: User, id: string): Promise<ApiStudentGroup | null> {
             const adminAccess = actor.role === Role.ADMIN;
             const model = await db.findUnique({
-                where: {
-                    id: id,
-                    ...(adminAccess
-                        ? {}
-                        : {
-                              users: {
-                                  some: {
-                                      userId: actor.id,
-                                      isAdmin: true
-                                  }
+                where: adminAccess
+                    ? { id }
+                    : {
+                          id: id,
+                          users: {
+                              some: {
+                                  userId: actor.id
                               }
-                          })
-                },
+                          }
+                      },
                 include: {
                     users: {
                         select: {
@@ -214,17 +211,7 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
             //
             // user IDs should be provided, otherwise the frontend will not be able to relate the groups to the users
             const all = await db.findMany({
-                where:
-                    actor.role === Role.ADMIN
-                        ? undefined
-                        : {
-                              users: {
-                                  some: {
-                                      userId: actor.id,
-                                      isAdmin: true
-                                  }
-                              }
-                          },
+                ...(actor.role === Role.ADMIN ? {} : { where: { users: { some: { userId: actor.id } } } }),
                 include: {
                     users: {
                         select: {

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -77,10 +77,15 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                 },
                 data: {
                     users: {
-                        connect: {
-                            id: {
-                                userId: userId,
-                                studentGroupId: record.id
+                        connectOrCreate: {
+                            where: {
+                                id: {
+                                    userId: userId,
+                                    studentGroupId: record.id
+                                }
+                            },
+                            create: {
+                                userId: userId
                             }
                         }
                     }
@@ -103,7 +108,7 @@ function StudentGroup(db: PrismaClient['studentGroup']) {
                 },
                 data: {
                     users: {
-                        disconnect: {
+                        delete: {
                             id: {
                                 userId: userId,
                                 studentGroupId: record.id

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -43,10 +43,10 @@ function User(db: PrismaClient['user']) {
         },
 
         async all(actor: DbUser): Promise<DbUser[]> {
-            if (actor.role === Role.ADMIN) {
+            if (hasElevatedAccess(actor.role)) {
                 return db.findMany({});
             }
-            return db.findMany({
+            const users = await db.findMany({
                 where: {
                     OR: [
                         {
@@ -60,9 +60,9 @@ function User(db: PrismaClient['user']) {
                             }
                         }
                     ]
-                },
-                distinct: ['id']
+                }
             });
+            return users;
         },
 
         async setRole(actor: DbUser, userId: string, role: Role): Promise<DbUser> {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -41,11 +41,7 @@ function User(db: PrismaClient['user']) {
                         {
                             studentGroups: {
                                 some: {
-                                    users: {
-                                        some: {
-                                            id: actor.id
-                                        }
-                                    }
+                                    userId: actor.id
                                 }
                             }
                         }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -11,6 +11,13 @@ const RoleAccessLevel: { [key in Role]: number } = {
     [Role.ADMIN]: 2
 };
 
+export const getAccessLevel = (role?: Role | null) => {
+    if (!role) {
+        return 0;
+    }
+    return RoleAccessLevel[role] || 0;
+};
+
 export const hasElevatedAccess = (role?: Role | null) => {
     if (!role) {
         return false;

--- a/src/routes/authConfig.ts
+++ b/src/routes/authConfig.ts
@@ -111,8 +111,12 @@ const authConfig: Config = {
             path: '/studentGroups',
             access: [
                 {
-                    methods: ['GET', 'PUT', 'POST', 'DELETE'],
+                    methods: ['GET'],
                     minRole: Role.STUDENT
+                },
+                {
+                    methods: ['GET', 'PUT', 'POST', 'DELETE'],
+                    minRole: Role.TEACHER
                 }
             ]
         },

--- a/src/routes/authConfig.ts
+++ b/src/routes/authConfig.ts
@@ -1,3 +1,5 @@
+import { Role } from '@prisma/client';
+
 interface Credentials {
     tenantID: string;
     clientID: string;
@@ -17,7 +19,7 @@ export interface AccessMatrix {
         path: string;
         access: {
             methods: ('GET' | 'POST' | 'PUT' | 'DELETE')[];
-            adminOnly: boolean;
+            minRole: Role;
         }[];
     };
 }
@@ -56,7 +58,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -65,7 +67,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET', 'POST'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -74,7 +76,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['DELETE', 'GET', 'POST', 'PUT'],
-                    adminOnly: true
+                    minRole: Role.TEACHER
                 }
             ]
         },
@@ -83,7 +85,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -92,7 +94,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET', 'PUT'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -101,7 +103,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -110,7 +112,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET', 'PUT', 'POST', 'DELETE'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -119,7 +121,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['POST', 'PUT', 'DELETE'],
-                    adminOnly: true
+                    minRole: Role.TEACHER
                 }
             ]
         },
@@ -128,7 +130,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET', 'PUT', 'POST', 'DELETE'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -137,11 +139,11 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET', 'POST'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 },
                 {
                     methods: ['PUT', 'DELETE'],
-                    adminOnly: true
+                    minRole: Role.TEACHER
                 }
             ]
         },
@@ -150,7 +152,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET'],
-                    adminOnly: true
+                    minRole: Role.TEACHER
                 }
             ]
         },
@@ -159,7 +161,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['GET', 'PUT'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         },
@@ -168,7 +170,7 @@ const authConfig: Config = {
             access: [
                 {
                     methods: ['POST'],
-                    adminOnly: false
+                    minRole: Role.STUDENT
                 }
             ]
         }

--- a/src/routes/authConfig.ts
+++ b/src/routes/authConfig.ts
@@ -109,12 +109,8 @@ const authConfig: Config = {
             path: '/studentGroups',
             access: [
                 {
-                    methods: ['GET'],
+                    methods: ['GET', 'PUT', 'POST', 'DELETE'],
                     adminOnly: false
-                },
-                {
-                    methods: ['PUT', 'POST', 'DELETE'],
-                    adminOnly: true
                 }
             ]
         },

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -7,7 +7,8 @@ import {
     find as findStudentGroup,
     update as updateStudentGroup,
     addUser as addStudentGroupUser,
-    removeUser as removeStudentGroupUser
+    removeUser as removeStudentGroupUser,
+    setAdminRole as setStudentGroupAdminRole
 } from '../controllers/studentGroups';
 import {
     create as createUserPermission,
@@ -69,6 +70,7 @@ router.put('/studentGroups/:id', updateStudentGroup);
 router.delete('/studentGroups/:id', deleteStudentGroup);
 router.post('/studentGroups/:id/members/:userId', addStudentGroupUser);
 router.delete('/studentGroups/:id/members/:userId', removeStudentGroupUser);
+router.post('/studentGroups/:id/:userId', setStudentGroupAdminRole);
 
 router.post('/permissions/user', createUserPermission);
 router.put('/permissions/user/:id', updateUserPermission);

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -70,7 +70,7 @@ router.put('/studentGroups/:id', updateStudentGroup);
 router.delete('/studentGroups/:id', deleteStudentGroup);
 router.post('/studentGroups/:id/members/:userId', addStudentGroupUser);
 router.delete('/studentGroups/:id/members/:userId', removeStudentGroupUser);
-router.post('/studentGroups/:id/:userId', setStudentGroupAdminRole);
+router.post('/studentGroups/:id/admins/:userId', setStudentGroupAdminRole);
 
 router.post('/permissions/user', createUserPermission);
 router.put('/permissions/user/:id', updateUserPermission);

--- a/src/routes/socketEventTypes.ts
+++ b/src/routes/socketEventTypes.ts
@@ -30,10 +30,7 @@ type TypeRecordMap = {
     [RecordType.UserPermission]: ApiUserPermission;
     [RecordType.GroupPermission]: ApiGroupPermission;
     [RecordType.DocumentRoot]: ApiDocumentRootWithoutDocuments;
-    [RecordType.StudentGroup]: Omit<ApiStudentGroup, 'userIds' | 'adminIds'> & {
-        userIds?: string[];
-        adminIds?: string[];
-    };
+    [RecordType.StudentGroup]: ApiStudentGroup;
     [RecordType.AllowedAction]: AllowedAction;
     [RecordType.CmsSettings]: CmsSettings;
 };

--- a/src/routes/socketEventTypes.ts
+++ b/src/routes/socketEventTypes.ts
@@ -3,6 +3,7 @@ import { ApiDocument } from '../models/Document';
 import { ApiUserPermission } from '../models/RootUserPermission';
 import { ApiGroupPermission } from '../models/RootGroupPermission';
 import { ApiDocumentRootWithoutDocuments } from '../models/DocumentRoot';
+import { ApiStudentGroup } from '../models/StudentGroup';
 
 export enum IoEvent {
     NEW_RECORD = 'NEW_RECORD',
@@ -18,6 +19,7 @@ export enum RecordType {
     UserPermission = 'UserPermission',
     GroupPermission = 'GroupPermission',
     DocumentRoot = 'DocumentRoot',
+    StudentGroup = 'StudentGroup',
     AllowedAction = 'AllowedAction',
     CmsSettings = 'CmsSettings'
 }
@@ -28,6 +30,10 @@ type TypeRecordMap = {
     [RecordType.UserPermission]: ApiUserPermission;
     [RecordType.GroupPermission]: ApiGroupPermission;
     [RecordType.DocumentRoot]: ApiDocumentRootWithoutDocuments;
+    [RecordType.StudentGroup]: Omit<ApiStudentGroup, 'userIds' | 'adminIds'> & {
+        userIds?: string[];
+        adminIds?: string[];
+    };
     [RecordType.AllowedAction]: AllowedAction;
     [RecordType.CmsSettings]: CmsSettings;
 };
@@ -105,6 +111,6 @@ export type ServerToClientEvents = {
 };
 
 export interface ClientToServerEvents {
-    [IoClientEvent.JOIN_ROOM]: (roomId: string, callback: () => void) => void;
-    [IoClientEvent.LEAVE_ROOM]: (roomId: string, callback: () => void) => void;
+    [IoClientEvent.JOIN_ROOM]: (roomId: string, callback: (joined: boolean) => void) => void;
+    [IoClientEvent.LEAVE_ROOM]: (roomId: string, callback: (left: boolean) => void) => void;
 }

--- a/src/routes/socketEvents.ts
+++ b/src/routes/socketEvents.ts
@@ -1,11 +1,10 @@
 /* istanbul ignore file */
 
-import type { User } from '@prisma/client';
+import { Role, type User } from '@prisma/client';
 import { Server } from 'socket.io';
 import Logger from '../utils/logger';
 import { ClientToServerEvents, IoEvent, IoClientEvent, ServerToClientEvents } from './socketEventTypes';
 import StudentGroup from '../models/StudentGroup';
-import { hasElevatedAccess } from '../models/User';
 
 export enum IoRoom {
     ADMIN = 'admin',
@@ -20,7 +19,7 @@ const EventRouter = (io: Server<ClientToServerEvents, ServerToClientEvents>) => 
         }
         socket.join(user.id);
 
-        if (hasElevatedAccess(user.role)) {
+        if (user.role === Role.ADMIN) {
             socket.join(IoRoom.ADMIN);
             socket.on(IoClientEvent.JOIN_ROOM, (roomId: string, callback: () => void) => {
                 socket.join(roomId);

--- a/src/routes/socketEvents.ts
+++ b/src/routes/socketEvents.ts
@@ -5,6 +5,7 @@ import { Server } from 'socket.io';
 import Logger from '../utils/logger';
 import { ClientToServerEvents, IoEvent, IoClientEvent, ServerToClientEvents } from './socketEventTypes';
 import StudentGroup from '../models/StudentGroup';
+import { hasElevatedAccess } from '../models/User';
 
 export enum IoRoom {
     ADMIN = 'admin',
@@ -19,7 +20,7 @@ const EventRouter = (io: Server<ClientToServerEvents, ServerToClientEvents>) => 
         }
         socket.join(user.id);
 
-        if (user.isAdmin) {
+        if (hasElevatedAccess(user.role)) {
             socket.join(IoRoom.ADMIN);
             socket.on(IoClientEvent.JOIN_ROOM, (roomId: string, callback: () => void) => {
                 socket.join(roomId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import passport from 'passport';
 import EventRouter from './routes/socketEvents';
 import { NextFunction, Request, Response } from 'express';
 import * as Sentry from '@sentry/node';
+import { HTTP403Error } from './utils/errors/Errors';
 
 const PORT = process.env.PORT || 3002;
 
@@ -51,7 +52,7 @@ io.use((socket, next) => {
     if ((socket.request as any).user) {
         next();
     } else {
-        next(new Error('unauthorized'));
+        next(new HTTP403Error('unauthorized'));
     }
 });
 


### PR DESCRIPTION
# User Roles and Group Admins
Backend-Changes for https://github.com/GBSL-Informatik/teaching-dev/pull/139
---

- make the m:n-relation  `users <-> studentGroups` explicite by introducing the join-table `userStudentGroups`
- add `isAdmin` to the `userStudentGroups` join-table. Like that a student group can be managed by an explicite set of users/teachers. The ApiResponse is now
```js
{
  name: 'HK-A',
  description: 'Halbklasse',
  /* ... */
  userIds: [/*...*/],
  adminIds: [/*...*/]
}
```
- change `User.isAdmin` to `User.role` with the Roles `STUDENT, TEACHER, ADMIN`.
- Allow TEACHERs to manage users from groups they have admin-rights.
- provide notifications through socketIo when student groups change
- allow users to join/leave groups they ar newly part of /are not anymore members of